### PR TITLE
updates for selection module

### DIFF
--- a/config/ZprimePreSelection.xml
+++ b/config/ZprimePreSelection.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd" [
 
   <!ENTITY PROOFdir  "/nfs/dust/cms/user/missirol/PROOF">
-  <!ENTITY PRESELdir "/nfs/dust/cms/user/missirol/Analysis7XY/preselection">
+  <!ENTITY PRESELdir "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/preselection">
 
   <!ENTITY ZP2000w20 SYSTEM "../../common/datasets/MC_Zp_TTJets_M2000W20_20x25.xml">
   <!ENTITY ZP3000w30 SYSTEM "../../common/datasets/MC_Zp_TTJets_M3000W30_20x25.xml">
@@ -15,11 +15,11 @@
     <Package Name="SUHH2ZprimeSemiLeptonic.par" />
 <!--
     <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&PRESELdir;/" PostFix="" TargetLumi="1" >
-
-    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&PRESELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="&PROOFdir;/" ProofNodes="5" >
 -->
+    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&PRESELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="&PROOFdir;/" ProofNodes="5" >
+<!--
     <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&PRESELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="pod://" ProofWorkDir="&PROOFdir;/" >
-
+-->
 
 <!--
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP1000w10" Cacheable="True">
@@ -27,7 +27,7 @@
           <InputTree Name="AnalysisTree" />
           <OutputTree Name="AnalysisTree" />
         </InputData>
-
+-->
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP2000w20" Cacheable="True">
           &ZP2000w20;
           <InputTree Name="AnalysisTree" />
@@ -39,7 +39,7 @@
           <InputTree Name="AnalysisTree" />
           <OutputTree Name="AnalysisTree" />
         </InputData>
-
+<!--
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP1000w100" Cacheable="True">
           &ZP1000w100;
           <InputTree Name="AnalysisTree" />
@@ -57,13 +57,13 @@
           <InputTree Name="AnalysisTree" />
 	  <OutputTree Name="AnalysisTree" />
         </InputData>
-
+-->
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="TTbar" Cacheable="True">
           &TTbar;
           <InputTree Name="AnalysisTree" />
 	  <OutputTree Name="AnalysisTree" />
         </InputData>
--->
+
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets" Cacheable="True">
           &WJets;
           <InputTree Name="AnalysisTree" />

--- a/config/ZprimePreSelection.xml
+++ b/config/ZprimePreSelection.xml
@@ -4,10 +4,12 @@
   <!ENTITY PROOFdir  "/nfs/dust/cms/user/missirol/PROOF">
   <!ENTITY PRESELdir "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/preselection">
 
+  <!ENTITY ZP1000w10 SYSTEM "../../common/datasets/MC_Zp_TTJets_M1000W10_20x25.xml">
   <!ENTITY ZP2000w20 SYSTEM "../../common/datasets/MC_Zp_TTJets_M2000W20_20x25.xml">
   <!ENTITY ZP3000w30 SYSTEM "../../common/datasets/MC_Zp_TTJets_M3000W30_20x25.xml">
   <!ENTITY TTbar     SYSTEM "../../common/datasets/MC_TTJets_20x25.xml">
   <!ENTITY WJets     SYSTEM "../../common/datasets/MC_WJets_LNu_20x25.xml">
+  <!ENTITY ZJets     SYSTEM "../../common/datasets/MC_ZJets_LL_20x25.xml">
 ]>
 
 <JobConfiguration JobName="ZprimePreSelectionJob" OutputLevel="INFO">
@@ -16,18 +18,18 @@
 <!--
     <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&PRESELdir;/" PostFix="" TargetLumi="1" >
 -->
-    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&PRESELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="&PROOFdir;/" ProofNodes="5" >
+    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&PRESELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="&PROOFdir;/" ProofNodes="10" >
 <!--
     <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&PRESELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="pod://" ProofWorkDir="&PROOFdir;/" >
 -->
 
-<!--
+
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP1000w10" Cacheable="True">
           &ZP1000w10;
           <InputTree Name="AnalysisTree" />
           <OutputTree Name="AnalysisTree" />
         </InputData>
--->
+
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP2000w20" Cacheable="True">
           &ZP2000w20;
           <InputTree Name="AnalysisTree" />
@@ -112,6 +114,12 @@
 	  <OutputTree Name="AnalysisTree" />
         </InputData>
 -->
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets" Cacheable="True">
+          &ZJets;
+          <InputTree Name="AnalysisTree" />
+	  <OutputTree Name="AnalysisTree" />
+        </InputData>
+
 
         <UserConfig>
             <Item Name="PrimaryVertexCollection" Value="offlineSlimmedPrimaryVertices" />

--- a/config/ZprimePreSelection.xml
+++ b/config/ZprimePreSelection.xml
@@ -13,13 +13,13 @@
 <JobConfiguration JobName="ZprimePreSelectionJob" OutputLevel="INFO">
     <Library Name="libSUHH2ZprimeSemiLeptonic"/>
     <Package Name="SUHH2ZprimeSemiLeptonic.par" />
-
-    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&PRESELdir;/" PostFix="" TargetLumi="1" >
 <!--
-    <Cycle Name="ZprimePreSelection" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="&PROOFdir;/" ProofNodes="2" OutputDirectory="&PRESELdir;/" PostFix="" TargetLumi="1" >
+    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&PRESELdir;/" PostFix="" TargetLumi="1" >
 
-    <Cycle Name="ZprimePreSelection" RunMode="PROOF" ProofServer="pod://" ProofWorkDir="&PROOFdir;/" OutputDirectory="&PRESELdir;/" PostFix="" TargetLumi="1" >
+    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&PRESELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="&PROOFdir;/" ProofNodes="5" >
 -->
+    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&PRESELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="pod://" ProofWorkDir="&PROOFdir;/" >
+
 
 <!--
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP1000w10" Cacheable="True">
@@ -27,7 +27,7 @@
           <InputTree Name="AnalysisTree" />
           <OutputTree Name="AnalysisTree" />
         </InputData>
--->
+
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP2000w20" Cacheable="True">
           &ZP2000w20;
           <InputTree Name="AnalysisTree" />
@@ -39,7 +39,7 @@
           <InputTree Name="AnalysisTree" />
           <OutputTree Name="AnalysisTree" />
         </InputData>
-<!--
+
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP1000w100" Cacheable="True">
           &ZP1000w100;
           <InputTree Name="AnalysisTree" />
@@ -57,13 +57,13 @@
           <InputTree Name="AnalysisTree" />
 	  <OutputTree Name="AnalysisTree" />
         </InputData>
--->
+
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="TTbar" Cacheable="True">
           &TTbar;
           <InputTree Name="AnalysisTree" />
 	  <OutputTree Name="AnalysisTree" />
         </InputData>
-
+-->
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets" Cacheable="True">
           &WJets;
           <InputTree Name="AnalysisTree" />

--- a/config/ZprimeSelection_ELEC.xml
+++ b/config/ZprimeSelection_ELEC.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd" [
 
+  <!ENTITY PROOFdir  "/nfs/dust/cms/user/missirol/PROOF">
   <!ENTITY PRESELdir "/nfs/dust/cms/user/missirol/Analysis7XY/preselection">
   <!ENTITY SELdir    "/nfs/dust/cms/user/missirol/Analysis7XY/selection/elec/">
 ]>
@@ -8,10 +9,12 @@
 <JobConfiguration JobName="ZprimeSelectionJob" OutputLevel="INFO">
     <Library Name="libSUHH2ZprimeSemiLeptonic"/>
     <Package Name="SUHH2ZprimeSemiLeptonic.par" />
-
-    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&SELdir;/" PostFix="" TargetLumi="1" >
 <!--
-    <Cycle Name="uhh2::AnalysisModuleRunner" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="/nfs/dust/cms/user/ottjoc/proof-wd/" ProofNodes="2" OutputDirectory="&SELdir;/" PostFix="" TargetLumi="1" >
+    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&SELdir;/" PostFix="" TargetLumi="1" >
+-->
+    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&SELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="&PROOFdir;/" ProofNodes="5" >
+<!--
+    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&SELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="pod://" ProofWorkDir="&PROOFdir;/" >
 -->
 
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP2000w20" Cacheable="False">
@@ -26,14 +29,14 @@
             <OutputTree Name="AnalysisTree" />
         </InputData>
 
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets" Cacheable="False">
-            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.WJets.root" Lumi="0.0"/>
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="TTbar" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.TTbar.root" Lumi="0.0"/>
             <InputTree Name="AnalysisTree" />
             <OutputTree Name="AnalysisTree" />
         </InputData>
 
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="TTbar" Cacheable="False">
-            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.TTbar.root" Lumi="0.0"/>
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.WJets.root" Lumi="0.0"/>
             <InputTree Name="AnalysisTree" />
             <OutputTree Name="AnalysisTree" />
         </InputData>
@@ -51,7 +54,7 @@
            <Item Name="GenParticleCollection" Value="GenParticles" />
 
            <Item Name="channel" Value="electron" />
-
+           <!--  <Item Name="triggername" Value="HLT_.." /> -->
            <Item Name="AnalysisModule" Value="ZprimeSelectionModule" />
         </UserConfig>
 

--- a/config/ZprimeSelection_ELEC.xml
+++ b/config/ZprimeSelection_ELEC.xml
@@ -3,7 +3,7 @@
 
   <!ENTITY PROOFdir  "/nfs/dust/cms/user/missirol/PROOF">
   <!ENTITY PRESELdir "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/preselection">
-  <!ENTITY SELdir    "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/selection/elec/">
+  <!ENTITY SELdir    "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/selection/150307_test/elec/">
 ]>
 
 <JobConfiguration JobName="ZprimeSelectionJob" OutputLevel="INFO">
@@ -12,10 +12,16 @@
 <!--
     <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&SELdir;/" PostFix="" TargetLumi="1" >
 -->
-    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&SELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="&PROOFdir;/" ProofNodes="5" >
+    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&SELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="&PROOFdir;/" ProofNodes="10" >
 <!--
     <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&SELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="pod://" ProofWorkDir="&PROOFdir;/" >
 -->
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP1000w10" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZP1000w10.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
 
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP2000w20" Cacheable="False">
             <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZP2000w20.root" Lumi="0.0"/>
@@ -28,7 +34,7 @@
             <InputTree Name="AnalysisTree" />
             <OutputTree Name="AnalysisTree" />
         </InputData>
-<!--
+
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="TTbar" Cacheable="False">
             <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.TTbar.root" Lumi="0.0"/>
             <InputTree Name="AnalysisTree" />
@@ -40,23 +46,31 @@
             <InputTree Name="AnalysisTree" />
             <OutputTree Name="AnalysisTree" />
         </InputData>
--->
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZJets.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
 
         <UserConfig>
-           <Item Name="PrimaryVertexCollection" Value="offlineSlimmedPrimaryVertices" />
-           <Item Name="ElectronCollection" Value="slimmedElectrons" />
-           <Item Name="MuonCollection" Value="slimmedMuons" />
-           <Item Name="TauCollection" Value="slimmedTaus" />
-           <Item Name="JetCollection" Value="patJetsAk4PFCHS" />
-           <Item Name="GenJetCollection" Value="slimmedGenJets" />
-           <Item Name="METName" Value="slimmedMETs" />
-           <Item Name="TopJetCollection" Value="patJetsCmsTopTagCHSPacked" />
-           <Item Name="GenParticleCollection" Value="GenParticles" />
+            <Item Name="PrimaryVertexCollection" Value="offlineSlimmedPrimaryVertices" />
+            <Item Name="ElectronCollection" Value="slimmedElectrons" />
+            <Item Name="MuonCollection" Value="slimmedMuons" />
+            <Item Name="TauCollection" Value="slimmedTaus" />
+            <Item Name="JetCollection" Value="patJetsAk4PFCHS" />
+            <Item Name="GenJetCollection" Value="slimmedGenJets" />
+            <Item Name="METName" Value="slimmedMETs" />
+            <Item Name="TopJetCollection" Value="patJetsCmsTopTagCHSPacked" />
+            <Item Name="GenParticleCollection" Value="GenParticles" />
 
-           <Item Name="channel" Value="electron" />
-          <!-- <Item Name="triggername" Value="HLT_.." /> -->
+            <Item Name="use_sframe_weight" Value="false" />
 
-           <Item Name="AnalysisModule" Value="ZprimeSelectionModule" />
+            <Item Name="channel" Value="electron" />
+           <!-- <Item Name="triggername" Value="HLT_.." /> -->
+
+            <Item Name="AnalysisModule" Value="ZprimeSelectionModule" />
         </UserConfig>
 
     </Cycle>

--- a/config/ZprimeSelection_ELEC.xml
+++ b/config/ZprimeSelection_ELEC.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd" [
 
   <!ENTITY PROOFdir  "/nfs/dust/cms/user/missirol/PROOF">
-  <!ENTITY PRESELdir "/nfs/dust/cms/user/missirol/Analysis7XY/preselection">
-  <!ENTITY SELdir    "/nfs/dust/cms/user/missirol/Analysis7XY/selection/elec/">
+  <!ENTITY PRESELdir "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/preselection">
+  <!ENTITY SELdir    "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/selection/elec/">
 ]>
 
 <JobConfiguration JobName="ZprimeSelectionJob" OutputLevel="INFO">
@@ -28,7 +28,7 @@
             <InputTree Name="AnalysisTree" />
             <OutputTree Name="AnalysisTree" />
         </InputData>
-
+<!--
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="TTbar" Cacheable="False">
             <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.TTbar.root" Lumi="0.0"/>
             <InputTree Name="AnalysisTree" />
@@ -40,7 +40,7 @@
             <InputTree Name="AnalysisTree" />
             <OutputTree Name="AnalysisTree" />
         </InputData>
-
+-->
 
         <UserConfig>
            <Item Name="PrimaryVertexCollection" Value="offlineSlimmedPrimaryVertices" />
@@ -54,7 +54,8 @@
            <Item Name="GenParticleCollection" Value="GenParticles" />
 
            <Item Name="channel" Value="electron" />
-           <!--  <Item Name="triggername" Value="HLT_.." /> -->
+          <!-- <Item Name="triggername" Value="HLT_.." /> -->
+
            <Item Name="AnalysisModule" Value="ZprimeSelectionModule" />
         </UserConfig>
 

--- a/config/ZprimeSelection_MUON.xml
+++ b/config/ZprimeSelection_MUON.xml
@@ -3,7 +3,7 @@
 
   <!ENTITY PROOFdir  "/nfs/dust/cms/user/missirol/PROOF">
   <!ENTITY PRESELdir "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/preselection">
-  <!ENTITY SELdir    "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/selection/muon/">
+  <!ENTITY SELdir    "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/selection/150307_test/muon/">
 ]>
 
 <JobConfiguration JobName="ZprimeSelectionJob" OutputLevel="INFO">
@@ -12,10 +12,16 @@
 <!--
     <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&SELdir;/" PostFix="" TargetLumi="1" >
 -->
-    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&SELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="&PROOFdir;/" ProofNodes="5" >
+    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&SELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="&PROOFdir;/" ProofNodes="10" >
 <!--
     <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&SELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="pod://" ProofWorkDir="&PROOFdir;/" >
 -->
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP1000w10" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZP1000w10.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
 
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP2000w20" Cacheable="False">
             <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZP2000w20.root" Lumi="0.0"/>
@@ -28,7 +34,7 @@
             <InputTree Name="AnalysisTree" />
             <OutputTree Name="AnalysisTree" />
         </InputData>
-<!--
+
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="TTbar" Cacheable="False">
             <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.TTbar.root" Lumi="0.0"/>
             <InputTree Name="AnalysisTree" />
@@ -40,23 +46,31 @@
             <InputTree Name="AnalysisTree" />
             <OutputTree Name="AnalysisTree" />
         </InputData>
--->
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZJets.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
 
         <UserConfig>
-           <Item Name="PrimaryVertexCollection" Value="offlineSlimmedPrimaryVertices" />
-           <Item Name="ElectronCollection" Value="slimmedElectrons" />
-           <Item Name="MuonCollection" Value="slimmedMuons" />
-           <Item Name="TauCollection" Value="slimmedTaus" />
-           <Item Name="JetCollection" Value="patJetsAk4PFCHS" />
-           <Item Name="GenJetCollection" Value="slimmedGenJets" />
-           <Item Name="METName" Value="slimmedMETs" />
-           <Item Name="TopJetCollection" Value="patJetsCmsTopTagCHSPacked" />
-           <Item Name="GenParticleCollection" Value="GenParticles" />
+            <Item Name="PrimaryVertexCollection" Value="offlineSlimmedPrimaryVertices" />
+            <Item Name="ElectronCollection" Value="slimmedElectrons" />
+            <Item Name="MuonCollection" Value="slimmedMuons" />
+            <Item Name="TauCollection" Value="slimmedTaus" />
+            <Item Name="JetCollection" Value="patJetsAk4PFCHS" />
+            <Item Name="GenJetCollection" Value="slimmedGenJets" />
+            <Item Name="METName" Value="slimmedMETs" />
+            <Item Name="TopJetCollection" Value="patJetsCmsTopTagCHSPacked" />
+            <Item Name="GenParticleCollection" Value="GenParticles" />
 
-           <Item Name="channel" Value="muon" />
-          <!-- <Item Name="triggername" Value="HLT_.." /> -->
+            <Item Name="use_sframe_weight" Value="false" />
 
-           <Item Name="AnalysisModule" Value="ZprimeSelectionModule" />
+            <Item Name="channel" Value="muon" />
+           <!-- <Item Name="triggername" Value="HLT_.." /> -->
+
+            <Item Name="AnalysisModule" Value="ZprimeSelectionModule" />
         </UserConfig>
 
     </Cycle>

--- a/config/ZprimeSelection_MUON.xml
+++ b/config/ZprimeSelection_MUON.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd" [
 
   <!ENTITY PROOFdir  "/nfs/dust/cms/user/missirol/PROOF">
-  <!ENTITY PRESELdir "/nfs/dust/cms/user/missirol/Analysis7XY/preselection">
-  <!ENTITY SELdir    "/nfs/dust/cms/user/missirol/Analysis7XY/selection/muon/">
+  <!ENTITY PRESELdir "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/preselection">
+  <!ENTITY SELdir    "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/selection/muon/">
 ]>
 
 <JobConfiguration JobName="ZprimeSelectionJob" OutputLevel="INFO">
@@ -28,7 +28,7 @@
             <InputTree Name="AnalysisTree" />
             <OutputTree Name="AnalysisTree" />
         </InputData>
-
+<!--
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="TTbar" Cacheable="False">
             <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.TTbar.root" Lumi="0.0"/>
             <InputTree Name="AnalysisTree" />
@@ -40,7 +40,7 @@
             <InputTree Name="AnalysisTree" />
             <OutputTree Name="AnalysisTree" />
         </InputData>
-
+-->
 
         <UserConfig>
            <Item Name="PrimaryVertexCollection" Value="offlineSlimmedPrimaryVertices" />
@@ -54,7 +54,8 @@
            <Item Name="GenParticleCollection" Value="GenParticles" />
 
            <Item Name="channel" Value="muon" />
-           <!--<Item Name="triggername" Value="HLT_.." /> -->
+          <!-- <Item Name="triggername" Value="HLT_.." /> -->
+
            <Item Name="AnalysisModule" Value="ZprimeSelectionModule" />
         </UserConfig>
 

--- a/config/ZprimeSelection_MUON.xml
+++ b/config/ZprimeSelection_MUON.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd" [
 
+  <!ENTITY PROOFdir  "/nfs/dust/cms/user/missirol/PROOF">
   <!ENTITY PRESELdir "/nfs/dust/cms/user/missirol/Analysis7XY/preselection">
   <!ENTITY SELdir    "/nfs/dust/cms/user/missirol/Analysis7XY/selection/muon/">
 ]>
@@ -8,34 +9,36 @@
 <JobConfiguration JobName="ZprimeSelectionJob" OutputLevel="INFO">
     <Library Name="libSUHH2ZprimeSemiLeptonic"/>
     <Package Name="SUHH2ZprimeSemiLeptonic.par" />
-
-    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&SELdir;/" PostFix="" TargetLumi="1" >
 <!--
-    <Cycle Name="uhh2::AnalysisModuleRunner" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="/nfs/dust/cms/user/ottjoc/proof-wd/" ProofNodes="2" OutputDirectory="&SELdir;/" PostFix="" TargetLumi="1" >
+    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&SELdir;/" PostFix="" TargetLumi="1" >
+-->
+    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&SELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="&PROOFdir;/" ProofNodes="5" >
+<!--
+    <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&SELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="pod://" ProofWorkDir="&PROOFdir;/" >
 -->
 
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP2000w20" Cacheable="False">
-            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZP2000w20.root" Lumi="0.0"/> 
-            <InputTree Name="AnalysisTree" /> 
-            <OutputTree Name="AnalysisTree" />  
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZP2000w20.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
         </InputData>
 
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP3000w30" Cacheable="False">
-            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZP3000w30.root" Lumi="0.0"/> 
-            <InputTree Name="AnalysisTree" /> 
-            <OutputTree Name="AnalysisTree" />  
-        </InputData>
-
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets" Cacheable="False">
-            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.WJets.root" Lumi="0.0"/> 
-            <InputTree Name="AnalysisTree" /> 
-            <OutputTree Name="AnalysisTree" />  
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZP3000w30.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
         </InputData>
 
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="TTbar" Cacheable="False">
-            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.TTbar.root" Lumi="0.0"/> 
-            <InputTree Name="AnalysisTree" /> 
-            <OutputTree Name="AnalysisTree" />  
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.TTbar.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.WJets.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
         </InputData>
 
 
@@ -51,7 +54,7 @@
            <Item Name="GenParticleCollection" Value="GenParticles" />
 
            <Item Name="channel" Value="muon" />
-
+           <!--<Item Name="triggername" Value="HLT_.." /> -->
            <Item Name="AnalysisModule" Value="ZprimeSelectionModule" />
         </UserConfig>
 

--- a/include/ZprimeSelectionHists.h
+++ b/include/ZprimeSelectionHists.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <TH1F.h>
+#include <TH2F.h>
 
 class ZprimeSelectionHists: public uhh2::Hists {
  public:
@@ -62,6 +63,6 @@ class ZprimeSelectionHists: public uhh2::Hists {
   TH1F* met__pt;
   TH1F* met__phi;
   TH1F* htlep__pt;
+  TH2F* met_VS_dphi_lep1;
+  TH2F* met_VS_dphi_jet1;
 };
-
-

--- a/include/ZprimeSelectionHists.h
+++ b/include/ZprimeSelectionHists.h
@@ -1,23 +1,67 @@
 #pragma once
 #include "UHH2/core/include/Hists.h"
 
-
-/**  \brief Example class for booking and filling histograms
- * 
- * NOTE: This class uses the 'hist' method to retrieve histograms.
- * This requires a string lookup and is therefore slow if you have
- * many histograms. Therefore, it is recommended to use histogram
- * pointers as member data instead, like in 'common/include/ElectronHists.h'.
- */
-
+#include <string>
+#include <TH1F.h>
 
 class ZprimeSelectionHists: public uhh2::Hists {
-public:
-    // use the same constructor arguments as Hists for forwarding:
-    ZprimeSelectionHists(uhh2::Context & ctx, const std::string & dirname);
+ public:
+  ZprimeSelectionHists(uhh2::Context & ctx, const std::string & dirname);
 
-    virtual void fill(const uhh2::Event & ev) override;
-    virtual ~ZprimeSelectionHists();
+  virtual void fill(const uhh2::Event & ev) override;
+
+ private:
+  TH1F* wgt;
+
+  // PV 
+  TH1F* pvN;
+
+  // MUON
+  TH1F* muoN;
+  TH1F* muo1__pt;
+  TH1F* muo1__eta;
+  TH1F* muo1__minDR_jet;
+  TH1F* muo1__pTrel_jet;
+  TH1F* muo1__minDR_topjet;
+  TH1F* muo2__pt;
+  TH1F* muo2__eta;
+  TH1F* muo2__minDR_jet;
+  TH1F* muo2__pTrel_jet;
+  TH1F* muo2__minDR_topjet;
+
+  // ELECTRON
+  TH1F* eleN;
+  TH1F* ele1__pt;
+  TH1F* ele1__eta;
+  TH1F* ele1__minDR_jet;
+  TH1F* ele1__pTrel_jet;
+  TH1F* ele1__minDR_topjet;
+  TH1F* ele2__pt;
+  TH1F* ele2__eta;
+  TH1F* ele2__minDR_jet;
+  TH1F* ele2__pTrel_jet;
+  TH1F* ele2__minDR_topjet;
+
+  // JET
+  TH1F* jetN;
+  TH1F* jet1__pt;
+  TH1F* jet1__eta;
+  TH1F* jet2__pt;
+  TH1F* jet2__eta;
+  TH1F* jet3__pt;
+  TH1F* jet3__eta;
+
+  // TOPJET
+  TH1F* topjetN;
+  TH1F* topjet1__pt;
+  TH1F* topjet1__eta;
+  TH1F* topjet2__pt;
+  TH1F* topjet2__eta;
+
+  // MET
+  TH1F* met__pt;
+  TH1F* met__phi;
+  TH1F* htlep__pt;
 };
 
 

--- a/include/ZprimeSemiLeptonicSelections.h
+++ b/include/ZprimeSemiLeptonicSelections.h
@@ -4,6 +4,7 @@
 #include "UHH2/core/include/Utils.h"
 #include "UHH2/core/include/Selection.h"
 #include "UHH2/common/include/ReconstructionHypothesisDiscriminators.h"
+#include "UHH2/common/include/ObjectIdUtils.h"
 #include "UHH2/common/include/TopJetIds.h"
 
 namespace uhh2 {
@@ -41,11 +42,21 @@ namespace uhh2 {
 
   class TwoDCut : public Selection {
    public:
-    TwoDCut(float min_deltaR, float min_pTrel): min_deltaR_(min_deltaR), min_pTrel_(min_pTrel) {}
+    explicit TwoDCut(float min_deltaR, float min_pTrel): min_deltaR_(min_deltaR), min_pTrel_(min_pTrel) {}
     virtual bool passes(const Event & event) override;
 
    private:
     float min_deltaR_, min_pTrel_;
+  };
+  /////
+
+  class TriangularCuts : public Selection {
+   public:
+    explicit TriangularCuts(float a, float b);
+    virtual bool passes(const Event & event) override;
+
+   private:
+    float a_, b_;
   };
   /////
 

--- a/src/ZprimePreSelectionModule.cxx
+++ b/src/ZprimePreSelectionModule.cxx
@@ -63,7 +63,7 @@ ZprimePreSelectionModule::ZprimePreSelectionModule(Context & ctx){
 
   // setup object cleaners
   muo_cleaner.reset(new MuonCleaner(AndId<Muon>(MuonIDTight(), PtEtaCut(45., 2.1))));
-  ele_cleaner.reset(new ElectronCleaner(AndId<Electron>(ElectronID_PHYS14_25ns_tight_noIso, PtEtaCut(35., 2.5))));
+  ele_cleaner.reset(new ElectronCleaner(AndId<Electron>(ElectronID_PHYS14_25ns_tight_noIso, PtEtaCut(50., 2.5))));
 
   jet_corrector.reset(new JetCorrector(JERFiles::PHYS14_L123_MC));
   jetlepton_cleaner.reset(new JetLeptonCleaner(JERFiles::PHYS14_L123_MC));

--- a/src/ZprimeSelectionHists.cxx
+++ b/src/ZprimeSelectionHists.cxx
@@ -17,12 +17,12 @@ ZprimeSelectionHists::ZprimeSelectionHists(Context & ctx, const std::string & di
 
   // MUON
   muoN = book<TH1F>("muoN", ";# of muons", 20, 0, 20);
-  muo1__pt = book<TH1F>("muo1__pt", ";muon p_{T} [GeV]", 180, 0, 900);
+  muo1__pt = book<TH1F>("muo1__pt", ";muon p_{T} [GeV]", 240, 0, 1200);
   muo1__eta = book<TH1F>("muo1__eta", ";muon #eta", 60, -3, 3);
   muo1__minDR_jet = book<TH1F>("muo1__minDR_jet", ";#DeltaR_{min}(#mu, jet)", 60, 0, 6);
   muo1__pTrel_jet = book<TH1F>("muo1__pTrel_jet", ";p_{T, rel}(#mu, jet)", 180, 0, 180);
   muo1__minDR_topjet = book<TH1F>("muo1__minDR_topjet", ";#DeltaR_{min}(#mu, topjet)", 60, 0, 6);
-  muo2__pt = book<TH1F>("muo2__pt", ";muon p_{T} [GeV]", 180, 0, 900);
+  muo2__pt = book<TH1F>("muo2__pt", ";muon p_{T} [GeV]", 240, 0, 1200);
   muo2__eta = book<TH1F>("muo2__eta", ";muon #eta", 60, -3, 3);
   muo2__minDR_jet = book<TH1F>("muo2__minDR_jet", ";#DeltaR_{min}(#mu, jet)", 60, 0, 6);
   muo2__pTrel_jet = book<TH1F>("muo2__pTrel_jet", ";p_{T, rel}(#mu, jet)", 180, 0, 180);
@@ -30,12 +30,12 @@ ZprimeSelectionHists::ZprimeSelectionHists(Context & ctx, const std::string & di
 
   // ELECTRON
   eleN = book<TH1F>("eleN", ";# of electrons", 20, 0, 20);
-  ele1__pt = book<TH1F>("ele1__pt", ";electron p_{T} [GeV]", 180, 0, 900);
+  ele1__pt = book<TH1F>("ele1__pt", ";electron p_{T} [GeV]", 240, 0, 1200);
   ele1__eta = book<TH1F>("ele1__eta", ";electron #eta", 60, -3, 3);
   ele1__minDR_jet = book<TH1F>("ele1__minDR_jet", ";#DeltaR_{min}(e, jet)", 60, 0, 6);
   ele1__pTrel_jet = book<TH1F>("ele1__pTrel_jet", ";p_{T, rel}(e, jet)", 180, 0, 180);
   ele1__minDR_topjet = book<TH1F>("ele1__minDR_topjet", ";#DeltaR_{min}(e, topjet)", 60, 0, 6);
-  ele2__pt = book<TH1F>("ele2__pt", ";electron p_{T} [GeV]", 180, 0, 900);
+  ele2__pt = book<TH1F>("ele2__pt", ";electron p_{T} [GeV]", 240, 0, 1200);
   ele2__eta = book<TH1F>("ele2__eta", ";electron #eta", 60, -3, 3);
   ele2__minDR_jet = book<TH1F>("ele2__minDR_jet", ";#DeltaR_{min}(e, jet)", 60, 0, 6);
   ele2__pTrel_jet = book<TH1F>("ele2__pTrel_jet", ";p_{T, rel}(e, jet)", 180, 0, 180);
@@ -43,18 +43,18 @@ ZprimeSelectionHists::ZprimeSelectionHists(Context & ctx, const std::string & di
 
   // JET
   jetN = book<TH1F>("jetN", ";# of jets", 20, 0, 20);
-  jet1__pt = book<TH1F>("jet1__pt", ";jet p_{T} [GeV]", 180, 0, 900);
+  jet1__pt = book<TH1F>("jet1__pt", ";jet p_{T} [GeV]", 180, 0, 1800);
   jet1__eta = book<TH1F>("jet1__eta", ";jet #eta", 60, -3, 3);
-  jet2__pt = book<TH1F>("jet2__pt", ";jet p_{T} [GeV]", 180, 0, 900);
+  jet2__pt = book<TH1F>("jet2__pt", ";jet p_{T} [GeV]", 180, 0, 1800);
   jet2__eta = book<TH1F>("jet2__eta", ";jet #eta", 60, -3, 3);
-  jet3__pt = book<TH1F>("jet3__pt", ";jet p_{T} [GeV]", 180, 0, 900);
+  jet3__pt = book<TH1F>("jet3__pt", ";jet p_{T} [GeV]", 180, 0, 1800);
   jet3__eta = book<TH1F>("jet3__eta", ";jet #eta", 60, -3, 3);
 
   // TOPJET
   topjetN = book<TH1F>("topjetN", ";# of topjets", 20, 0, 20);
-  topjet1__pt = book<TH1F>("topjet1__pt", ";topjet p_{T} [GeV]", 180, 0, 900);
+  topjet1__pt = book<TH1F>("topjet1__pt", ";topjet p_{T} [GeV]", 180, 0, 1800);
   topjet1__eta = book<TH1F>("topjet1__eta", ";topjet #eta", 60, -3, 3);
-  topjet2__pt = book<TH1F>("topjet2__pt", ";topjet p_{T} [GeV]", 180, 0, 900);
+  topjet2__pt = book<TH1F>("topjet2__pt", ";topjet p_{T} [GeV]", 180, 0, 1800);
   topjet2__eta = book<TH1F>("topjet2__eta", ";topjet #eta", 60, -3, 3);
 
   // MET
@@ -186,9 +186,7 @@ void ZprimeSelectionHists::fill(const Event & event){
 
   /* triangular cuts vars */
   if(lep1) met_VS_dphi_lep1->Fill(event.met->pt(), fabs(deltaPhi(*event.met, *lep1)), weight);
-
-  const Particle* jet1 = &event.jets->at(0);
-  if(jet1) met_VS_dphi_jet1->Fill(event.met->pt(), fabs(deltaPhi(*event.met, *jet1)), weight);
+  if(event.jets->size()) met_VS_dphi_jet1->Fill(event.met->pt(), fabs(deltaPhi(*event.met, event.jets->at(0))), weight);
 
   return;
 }

--- a/src/ZprimeSelectionHists.cxx
+++ b/src/ZprimeSelectionHists.cxx
@@ -10,57 +10,59 @@ using namespace uhh2;
 
 ZprimeSelectionHists::ZprimeSelectionHists(Context & ctx, const std::string & dirname): Hists(ctx, dirname){
 
-  wgt = book<TH1F>("weight", "event weight", 120, 0, 12);
+  wgt = book<TH1F>("weight", ";event weight", 120, 0, 12);
 
   // PV
-  pvN = book<TH1F>("pvN", "# of primary vertices", 60, 0, 60);
+  pvN = book<TH1F>("pvN", ";# of primary vertices", 60, 0, 60);
 
   // MUON
-  muoN = book<TH1F>("muoN", "# of muons", 20, 0, 20);
-  muo1__pt = book<TH1F>("muo1__pt", "muon p_{T} [GeV]", 180, 0, 900);
-  muo1__eta = book<TH1F>("muo1__eta", "muon #eta", 60, -3, 3);
-  muo1__minDR_jet = book<TH1F>("muo1__minDR_jet", "#DeltaR_{min}(#mu, jet)", 60, 0, 6);
-  muo1__pTrel_jet = book<TH1F>("muo1__pTrel_jet", "p_{T, rel}(#mu, jet)", 180, 0, 180);
-  muo1__minDR_topjet = book<TH1F>("muo1__minDR_topjet", "#DeltaR_{min}(#mu, topjet)", 60, 0, 6);
-  muo2__pt = book<TH1F>("muo2__pt", "muon p_{T} [GeV]", 180, 0, 900);
-  muo2__eta = book<TH1F>("muo2__eta", "muon #eta", 60, -3, 3);
-  muo2__minDR_jet = book<TH1F>("muo2__minDR_jet", "#DeltaR_{min}(#mu, jet)", 60, 0, 6);
-  muo2__pTrel_jet = book<TH1F>("muo2__pTrel_jet", "p_{T, rel}(#mu, jet)", 180, 0, 180);
-  muo2__minDR_topjet = book<TH1F>("muo2__minDR_topjet", "#DeltaR_{min}(#mu, topjet)", 60, 0, 6);
+  muoN = book<TH1F>("muoN", ";# of muons", 20, 0, 20);
+  muo1__pt = book<TH1F>("muo1__pt", ";muon p_{T} [GeV]", 180, 0, 900);
+  muo1__eta = book<TH1F>("muo1__eta", ";muon #eta", 60, -3, 3);
+  muo1__minDR_jet = book<TH1F>("muo1__minDR_jet", ";#DeltaR_{min}(#mu, jet)", 60, 0, 6);
+  muo1__pTrel_jet = book<TH1F>("muo1__pTrel_jet", ";p_{T, rel}(#mu, jet)", 180, 0, 180);
+  muo1__minDR_topjet = book<TH1F>("muo1__minDR_topjet", ";#DeltaR_{min}(#mu, topjet)", 60, 0, 6);
+  muo2__pt = book<TH1F>("muo2__pt", ";muon p_{T} [GeV]", 180, 0, 900);
+  muo2__eta = book<TH1F>("muo2__eta", ";muon #eta", 60, -3, 3);
+  muo2__minDR_jet = book<TH1F>("muo2__minDR_jet", ";#DeltaR_{min}(#mu, jet)", 60, 0, 6);
+  muo2__pTrel_jet = book<TH1F>("muo2__pTrel_jet", ";p_{T, rel}(#mu, jet)", 180, 0, 180);
+  muo2__minDR_topjet = book<TH1F>("muo2__minDR_topjet", ";#DeltaR_{min}(#mu, topjet)", 60, 0, 6);
 
   // ELECTRON
-  eleN = book<TH1F>("eleN", "# of electrons", 20, 0, 20);
-  ele1__pt = book<TH1F>("ele1__pt", "electron p_{T} [GeV]", 180, 0, 900);
-  ele1__eta = book<TH1F>("ele1__eta", "electron #eta", 60, -3, 3);
-  ele1__minDR_jet = book<TH1F>("ele1__minDR_jet", "#DeltaR_{min}(e, jet)", 60, 0, 6);
-  ele1__pTrel_jet = book<TH1F>("ele1__pTrel_jet", "p_{T, rel}(e, jet)", 180, 0, 180);
-  ele1__minDR_topjet = book<TH1F>("ele1__minDR_topjet", "#DeltaR_{min}(e, topjet)", 60, 0, 6);
-  ele2__pt = book<TH1F>("ele2__pt", "electron p_{T} [GeV]", 180, 0, 900);
-  ele2__eta = book<TH1F>("ele2__eta", "electron #eta", 60, -3, 3);
-  ele2__minDR_jet = book<TH1F>("ele2__minDR_jet", "#DeltaR_{min}(e, jet)", 60, 0, 6);
-  ele2__pTrel_jet = book<TH1F>("ele2__pTrel_jet", "p_{T, rel}(e, jet)", 180, 0, 180);
-  ele2__minDR_topjet = book<TH1F>("ele2__minDR_topjet", "#DeltaR_{min}(e, topjet)", 60, 0, 6);
+  eleN = book<TH1F>("eleN", ";# of electrons", 20, 0, 20);
+  ele1__pt = book<TH1F>("ele1__pt", ";electron p_{T} [GeV]", 180, 0, 900);
+  ele1__eta = book<TH1F>("ele1__eta", ";electron #eta", 60, -3, 3);
+  ele1__minDR_jet = book<TH1F>("ele1__minDR_jet", ";#DeltaR_{min}(e, jet)", 60, 0, 6);
+  ele1__pTrel_jet = book<TH1F>("ele1__pTrel_jet", ";p_{T, rel}(e, jet)", 180, 0, 180);
+  ele1__minDR_topjet = book<TH1F>("ele1__minDR_topjet", ";#DeltaR_{min}(e, topjet)", 60, 0, 6);
+  ele2__pt = book<TH1F>("ele2__pt", ";electron p_{T} [GeV]", 180, 0, 900);
+  ele2__eta = book<TH1F>("ele2__eta", ";electron #eta", 60, -3, 3);
+  ele2__minDR_jet = book<TH1F>("ele2__minDR_jet", ";#DeltaR_{min}(e, jet)", 60, 0, 6);
+  ele2__pTrel_jet = book<TH1F>("ele2__pTrel_jet", ";p_{T, rel}(e, jet)", 180, 0, 180);
+  ele2__minDR_topjet = book<TH1F>("ele2__minDR_topjet", ";#DeltaR_{min}(e, topjet)", 60, 0, 6);
 
   // JET
-  jetN = book<TH1F>("jetN", "# of jets", 20, 0, 20);
-  jet1__pt = book<TH1F>("jet1__pt", "jet p_{T} [GeV]", 180, 0, 900);
-  jet1__eta = book<TH1F>("jet1__eta", "jet #eta", 60, -3, 3);
-  jet2__pt = book<TH1F>("jet2__pt", "jet p_{T} [GeV]", 180, 0, 900);
-  jet2__eta = book<TH1F>("jet2__eta", "jet #eta", 60, -3, 3);
-  jet3__pt = book<TH1F>("jet3__pt", "jet p_{T} [GeV]", 180, 0, 900);
-  jet3__eta = book<TH1F>("jet3__eta", "jet #eta", 60, -3, 3);
+  jetN = book<TH1F>("jetN", ";# of jets", 20, 0, 20);
+  jet1__pt = book<TH1F>("jet1__pt", ";jet p_{T} [GeV]", 180, 0, 900);
+  jet1__eta = book<TH1F>("jet1__eta", ";jet #eta", 60, -3, 3);
+  jet2__pt = book<TH1F>("jet2__pt", ";jet p_{T} [GeV]", 180, 0, 900);
+  jet2__eta = book<TH1F>("jet2__eta", ";jet #eta", 60, -3, 3);
+  jet3__pt = book<TH1F>("jet3__pt", ";jet p_{T} [GeV]", 180, 0, 900);
+  jet3__eta = book<TH1F>("jet3__eta", ";jet #eta", 60, -3, 3);
 
   // TOPJET
-  topjetN = book<TH1F>("topjetN", "# of topjets", 20, 0, 20);
-  topjet1__pt = book<TH1F>("topjet1__pt", "topjet p_{T} [GeV]", 180, 0, 900);
-  topjet1__eta = book<TH1F>("topjet1__eta", "topjet #eta", 60, -3, 3);
-  topjet2__pt = book<TH1F>("topjet2__pt", "topjet p_{T} [GeV]", 180, 0, 900);
-  topjet2__eta = book<TH1F>("topjet2__eta", "topjet #eta", 60, -3, 3);
+  topjetN = book<TH1F>("topjetN", ";# of topjets", 20, 0, 20);
+  topjet1__pt = book<TH1F>("topjet1__pt", ";topjet p_{T} [GeV]", 180, 0, 900);
+  topjet1__eta = book<TH1F>("topjet1__eta", ";topjet #eta", 60, -3, 3);
+  topjet2__pt = book<TH1F>("topjet2__pt", ";topjet p_{T} [GeV]", 180, 0, 900);
+  topjet2__eta = book<TH1F>("topjet2__eta", ";topjet #eta", 60, -3, 3);
 
   // MET
-  met__pt = book<TH1F>("met__pt", "MET [GeV]", 180, 0, 1800);
-  met__phi = book<TH1F>("met__phi", "MET #phi", 72, -3.6, 3.6);
-  htlep__pt = book<TH1F>("htlep__pt", "H_{T}^{lep} [GeV]", 180, 0, 1800);
+  met__pt = book<TH1F>("met__pt", ";MET [GeV]", 180, 0, 1800);
+  met__phi = book<TH1F>("met__phi", ";MET #phi", 72, -3.6, 3.6);
+  htlep__pt = book<TH1F>("htlep__pt", ";H_{T}^{lep} [GeV]", 180, 0, 1800);
+  met_VS_dphi_lep1 = book<TH2F>("met_VS_dphi_lep1", ";MET [GeV];#Delta#phi(MET, l1)", 180, 0, 1800, 60, 0, 3.6);
+  met_VS_dphi_jet1 = book<TH2F>("met_VS_dphi_jet1", ";MET [GeV];#Delta#phi(MET, l1)", 180, 0, 1800, 60, 0, 3.6);
 }
 
 void ZprimeSelectionHists::fill(const Event & event){
@@ -181,6 +183,12 @@ void ZprimeSelectionHists::fill(const Event & event){
   for(const auto& l : *event.muons)     if(l.pt() > max_lep_pt){ lep1 = &l; max_lep_pt = l.pt(); }
   for(const auto& l : *event.electrons) if(l.pt() > max_lep_pt){ lep1 = &l; max_lep_pt = l.pt(); }
   if(lep1) htlep__pt->Fill(event.met->pt()+lep1->pt(), weight);
+
+  /* triangular cuts vars */
+  if(lep1) met_VS_dphi_lep1->Fill(event.met->pt(), fabs(deltaPhi(*event.met, *lep1)), weight);
+
+  const Particle* jet1 = &event.jets->at(0);
+  if(jet1) met_VS_dphi_jet1->Fill(event.met->pt(), fabs(deltaPhi(*event.met, *jet1)), weight);
 
   return;
 }

--- a/src/ZprimeSelectionHists.cxx
+++ b/src/ZprimeSelectionHists.cxx
@@ -1,76 +1,186 @@
 #include "UHH2/ZprimeSemiLeptonic/include/ZprimeSelectionHists.h"
 #include "UHH2/core/include/Event.h"
+#include "UHH2/core/include/Utils.h"
+#include "UHH2/common/include/Utils.h"
 
-#include "TH1F.h"
 #include <iostream>
+#include <TH1F.h>
 
-
-using namespace std;
 using namespace uhh2;
 
-ZprimeSelectionHists::ZprimeSelectionHists(Context & ctx, const string & dirname): Hists(ctx, dirname){
-  // book all histograms here
-  // jets
-  //book<TH1F>("N_jets", "N_{jets}", 20, 0, 20);  
-  //book<TH1F>("eta_jet1", "#eta^{jet 1}", 40, -2.5, 2.5);
-  //book<TH1F>("eta_jet2", "#eta^{jet 2}", 40, -2.5, 2.5);
-  //book<TH1F>("eta_jet3", "#eta^{jet 3}", 40, -2.5, 2.5);
-  //book<TH1F>("eta_jet4", "#eta^{jet 4}", 40, -2.5, 2.5);
+ZprimeSelectionHists::ZprimeSelectionHists(Context & ctx, const std::string & dirname): Hists(ctx, dirname){
 
-  // leptons
-  //book<TH1F>("N_mu", "N^{#mu}", 10, 0, 10);
-  //book<TH1F>("pt_mu", "p_{T}^{#mu} [GeV/c]", 40, 0, 200);
-  //book<TH1F>("eta_mu", "#eta^{#mu}", 40, -2.1, 2.1);
-  //book<TH1F>("reliso_mu", "#mu rel. Iso", 40, 0, 0.5);
+  wgt = book<TH1F>("weight", "event weight", 120, 0, 12);
 
-  // primary vertices
-  //book<TH1F>("N_pv", "N^{PV}", 50, 0, 50);
+  // PV
+  pvN = book<TH1F>("pvN", "# of primary vertices", 60, 0, 60);
 
-  //
+  // MUON
+  muoN = book<TH1F>("muoN", "# of muons", 20, 0, 20);
+  muo1__pt = book<TH1F>("muo1__pt", "muon p_{T} [GeV]", 180, 0, 900);
+  muo1__eta = book<TH1F>("muo1__eta", "muon #eta", 60, -3, 3);
+  muo1__minDR_jet = book<TH1F>("muo1__minDR_jet", "#DeltaR_{min}(#mu, jet)", 60, 0, 6);
+  muo1__pTrel_jet = book<TH1F>("muo1__pTrel_jet", "p_{T, rel}(#mu, jet)", 180, 0, 180);
+  muo1__minDR_topjet = book<TH1F>("muo1__minDR_topjet", "#DeltaR_{min}(#mu, topjet)", 60, 0, 6);
+  muo2__pt = book<TH1F>("muo2__pt", "muon p_{T} [GeV]", 180, 0, 900);
+  muo2__eta = book<TH1F>("muo2__eta", "muon #eta", 60, -3, 3);
+  muo2__minDR_jet = book<TH1F>("muo2__minDR_jet", "#DeltaR_{min}(#mu, jet)", 60, 0, 6);
+  muo2__pTrel_jet = book<TH1F>("muo2__pTrel_jet", "p_{T, rel}(#mu, jet)", 180, 0, 180);
+  muo2__minDR_topjet = book<TH1F>("muo2__minDR_topjet", "#DeltaR_{min}(#mu, topjet)", 60, 0, 6);
 
+  // ELECTRON
+  eleN = book<TH1F>("eleN", "# of electrons", 20, 0, 20);
+  ele1__pt = book<TH1F>("ele1__pt", "electron p_{T} [GeV]", 180, 0, 900);
+  ele1__eta = book<TH1F>("ele1__eta", "electron #eta", 60, -3, 3);
+  ele1__minDR_jet = book<TH1F>("ele1__minDR_jet", "#DeltaR_{min}(e, jet)", 60, 0, 6);
+  ele1__pTrel_jet = book<TH1F>("ele1__pTrel_jet", "p_{T, rel}(e, jet)", 180, 0, 180);
+  ele1__minDR_topjet = book<TH1F>("ele1__minDR_topjet", "#DeltaR_{min}(e, topjet)", 60, 0, 6);
+  ele2__pt = book<TH1F>("ele2__pt", "electron p_{T} [GeV]", 180, 0, 900);
+  ele2__eta = book<TH1F>("ele2__eta", "electron #eta", 60, -3, 3);
+  ele2__minDR_jet = book<TH1F>("ele2__minDR_jet", "#DeltaR_{min}(e, jet)", 60, 0, 6);
+  ele2__pTrel_jet = book<TH1F>("ele2__pTrel_jet", "p_{T, rel}(e, jet)", 180, 0, 180);
+  ele2__minDR_topjet = book<TH1F>("ele2__minDR_topjet", "#DeltaR_{min}(e, topjet)", 60, 0, 6);
 
+  // JET
+  jetN = book<TH1F>("jetN", "# of jets", 20, 0, 20);
+  jet1__pt = book<TH1F>("jet1__pt", "jet p_{T} [GeV]", 180, 0, 900);
+  jet1__eta = book<TH1F>("jet1__eta", "jet #eta", 60, -3, 3);
+  jet2__pt = book<TH1F>("jet2__pt", "jet p_{T} [GeV]", 180, 0, 900);
+  jet2__eta = book<TH1F>("jet2__eta", "jet #eta", 60, -3, 3);
+  jet3__pt = book<TH1F>("jet3__pt", "jet p_{T} [GeV]", 180, 0, 900);
+  jet3__eta = book<TH1F>("jet3__eta", "jet #eta", 60, -3, 3);
+
+  // TOPJET
+  topjetN = book<TH1F>("topjetN", "# of topjets", 20, 0, 20);
+  topjet1__pt = book<TH1F>("topjet1__pt", "topjet p_{T} [GeV]", 180, 0, 900);
+  topjet1__eta = book<TH1F>("topjet1__eta", "topjet #eta", 60, -3, 3);
+  topjet2__pt = book<TH1F>("topjet2__pt", "topjet p_{T} [GeV]", 180, 0, 900);
+  topjet2__eta = book<TH1F>("topjet2__eta", "topjet #eta", 60, -3, 3);
+
+  // MET
+  met__pt = book<TH1F>("met__pt", "MET [GeV]", 180, 0, 1800);
+  met__phi = book<TH1F>("met__phi", "MET #phi", 72, -3.6, 3.6);
+  htlep__pt = book<TH1F>("htlep__pt", "H_{T}^{lep} [GeV]", 180, 0, 1800);
 }
-
 
 void ZprimeSelectionHists::fill(const Event & event){
-  // fill the histograms. Please note the comments in the header file:
-  // 'hist' is used here a lot for simplicity, but it will be rather
-  // slow when you have many histograms; therefore, better
-  // use histogram pointers as members as in 'UHH2/common/include/ElectronHists.h'
-  
-  // Don't forget to always use the weight when filling.
-  
-  /* 
-  double weight = event.weight;
-  
-  std::vector<Jet>* jets = event.jets;
-  int Njets = jets->size();
-  hist("N_jets")->Fill(Njets, weight);
-  
-  if(Njets>=1){
-  hist("eta_jet1")->Fill(jets->at(0).eta(), weight);
-  }
-  if(Njets>=2){
-  hist("eta_jet2")->Fill(jets->at(1).eta(), weight);
-  }
-  if(Njets>=3){
-  hist("eta_jet3")->Fill(jets->at(2).eta(), weight);
-  }
-  if(Njets>=4){
-  hist("eta_jet4")->Fill(jets->at(3).eta(), weight);
+
+  assert(event.pvs && event.muons && event.electrons);
+  assert(event.jets && event.topjets && event.met);
+
+  const double weight = event.weight;
+  wgt->Fill(weight);
+
+  // PV
+  pvN->Fill(event.pvs->size(), weight);
+
+  // MUON
+  int muo_n(event.muons->size());
+  muoN->Fill(muo_n, weight);
+
+  for(int i=0; i<std::min(2, muo_n); ++i){
+    const Particle& p = event.muons->at(i);
+
+    float minDR_jet(-1.), pTrel_jet(-1.);
+    std::tie(minDR_jet, pTrel_jet) = drmin_pTrel(p, *event.jets);
+
+    float minDR_topjet(infinity);
+    for(const auto& tj: *event.topjets)
+      if(deltaR(p, tj) < minDR_topjet) minDR_topjet = deltaR(p, tj);
+
+    if(i == 0){
+      muo1__pt->Fill(p.pt(), weight);
+      muo1__eta->Fill(p.eta(), weight);
+      muo1__minDR_jet->Fill(minDR_jet, weight);
+      muo1__pTrel_jet->Fill(pTrel_jet, weight);
+      muo1__minDR_topjet->Fill(minDR_topjet, weight);
+    }
+    else if(i == 1){
+      muo2__pt->Fill(p.pt(), weight);
+      muo2__eta->Fill(p.eta(), weight);
+      muo2__minDR_jet->Fill(minDR_jet, weight);
+      muo2__pTrel_jet->Fill(pTrel_jet, weight);
+      muo2__minDR_topjet->Fill(minDR_topjet, weight);
+    }
   }
 
-  int Nmuons = event.muons->size();
-  hist("N_mu")->Fill(Nmuons, weight);
-  for (const Muon & thismu : *event.muons){
-  hist("pt_mu")->Fill(thismu.pt(), weight);
-  hist("eta_mu")->Fill(thismu.eta(), weight);
-  hist("reliso_mu")->Fill(thismu.relIso(), weight);
+  // ELECTRON
+  int ele_n(event.electrons->size());
+  eleN->Fill(ele_n, weight);
+
+  for(int i=0; i<std::min(2, ele_n); ++i){
+    const Particle& p = event.electrons->at(i);
+
+    float minDR_jet(-1.), pTrel_jet(-1.);
+    std::tie(minDR_jet, pTrel_jet) = drmin_pTrel(p, *event.jets);
+
+    float minDR_topjet(infinity);
+    for(const auto& tj: *event.topjets)
+      if(deltaR(p, tj) < minDR_topjet) minDR_topjet = deltaR(p, tj);
+
+    if(i == 0){
+      ele1__pt->Fill(p.pt(), weight);
+      ele1__eta->Fill(p.eta(), weight);
+      ele1__minDR_jet->Fill(minDR_jet, weight);
+      ele1__pTrel_jet->Fill(pTrel_jet, weight);
+      ele1__minDR_topjet->Fill(minDR_topjet, weight);
+    }
+    else if(i == 1){
+      ele2__pt->Fill(p.pt(), weight);
+      ele2__eta->Fill(p.eta(), weight);
+      ele2__minDR_jet->Fill(minDR_jet, weight);
+      ele2__pTrel_jet->Fill(pTrel_jet, weight);
+      ele2__minDR_topjet->Fill(minDR_topjet, weight);
+    }
   }
-  
-  int Npvs = event.pvs->size();
-  hist("N_pv")->Fill(Npvs, weight);
-  */
+
+  // JET
+  int jet_n(event.jets->size());
+  jetN->Fill(jet_n, weight);
+
+  for(int i=0; i<std::min(3, jet_n); ++i){
+    const Particle& p = event.jets->at(i);
+
+    if(i == 0){
+      jet1__pt->Fill(p.pt(), weight);
+      jet1__eta->Fill(p.eta(), weight);
+    }
+    else if(i == 1){
+      jet2__pt->Fill(p.pt(), weight);
+      jet2__eta->Fill(p.eta(), weight);
+    }
+    else if(i == 2){
+      jet3__pt->Fill(p.pt(), weight);
+      jet3__eta->Fill(p.eta(), weight);
+    }
+  }
+
+  // TOPJET
+  int topjet_n(event.topjets->size());
+  topjetN->Fill(topjet_n, weight);
+
+  for(int i=0; i<std::min(2, topjet_n); ++i){
+    const Particle& p = event.topjets->at(i);
+
+    if(i == 0){
+      topjet1__pt->Fill(p.pt(), weight);
+      topjet1__eta->Fill(p.eta(), weight);
+    }
+    else if(i == 1){
+      topjet2__pt->Fill(p.pt(), weight);
+      topjet2__eta->Fill(p.eta(), weight);
+    }
+  }
+
+  // MET
+  met__pt->Fill(event.met->pt(), weight);
+  met__phi->Fill(event.met->phi(), weight);
+
+  const Particle* lep1(0);
+  float max_lep_pt(0.);
+  for(const auto& l : *event.muons)     if(l.pt() > max_lep_pt){ lep1 = &l; max_lep_pt = l.pt(); }
+  for(const auto& l : *event.electrons) if(l.pt() > max_lep_pt){ lep1 = &l; max_lep_pt = l.pt(); }
+  if(lep1) htlep__pt->Fill(event.met->pt()+lep1->pt(), weight);
+
+  return;
 }
-
-ZprimeSelectionHists::~ZprimeSelectionHists(){}

--- a/src/ZprimeSelectionModule.cxx
+++ b/src/ZprimeSelectionModule.cxx
@@ -3,36 +3,48 @@
 
 #include "UHH2/core/include/AnalysisModule.h"
 #include "UHH2/core/include/Event.h"
-#include "UHH2/common/include/EventHists.h"
-#include "UHH2/common/include/EventVariables.h"
+#include "UHH2/core/include/Selection.h"
+
 #include "UHH2/common/include/CleaningModules.h"
 #include "UHH2/common/include/NSelections.h"
-#include "UHH2/common/include/MuonHists.h"
 #include "UHH2/common/include/MuonIds.h"
-#include "UHH2/common/include/ElectronHists.h"
 #include "UHH2/common/include/ElectronIds.h"
-#include "UHH2/common/include/TopJetIds.h"
-#include "UHH2/common/include/JetHists.h"
 #include "UHH2/common/include/JetIds.h"
-#include "UHH2/ZprimeSemiLeptonic/include/ZprimeSemiLeptonicSelections.h"
-#include "UHH2/ZprimeSemiLeptonic/include/ZprimeSemiLeptonicUtils.h"
-#include "UHH2/ZprimeSemiLeptonic/include/ZprimeSelectionHists.h"
+#include "UHH2/common/include/TopJetIds.h"
 #include "UHH2/common/include/JetCorrections.h"
 #include "UHH2/common/include/ObjectIdUtils.h"
 #include "UHH2/common/include/Utils.h"
-#include "UHH2/core/include/Selection.h"
+#include "UHH2/common/include/TTbarGen.h"
 #include "UHH2/common/include/TTbarReconstruction.h"
 #include "UHH2/common/include/ReconstructionHypothesisDiscriminators.h"
 #include "UHH2/common/include/HypothesisHists.h"
 #include "UHH2/common/include/TriggerSelection.h"
-//
-// -- ITEMS TO BE IMPLEMENTED
-//   * trigger selection
-//   * update 2D cut values and thresholds for leptons and jets according to the HLT paths
-//   * primary vertex selection
-//   * triangular cuts (electron only)
-//   * JER smearing for TopJet collection
-//
+
+#include "UHH2/ZprimeSemiLeptonic/include/ZprimeSemiLeptonicSelections.h"
+#include "UHH2/ZprimeSemiLeptonic/include/ZprimeSemiLeptonicUtils.h"
+#include "UHH2/ZprimeSemiLeptonic/include/ZprimeSelectionHists.h"
+
+/** \brief module to produce "Selection" ntuples for the Z'->ttbar semileptonic analysis
+ *
+ *  -- GOALS:
+ *   * complete object reconstruction (pt/eta cuts, IDs, jet-lepton cleaning, JER smearing)
+ *   * apply (most of) the kinematic cuts for the lepton+jets SR. current cutflow:
+ *     * HLT
+ *     * ==1 lepton (w/ pt+eta+ID cuts)
+ *     * >=2 AK4 jets w/ pt> 50 |eta|<2.4
+ *     * >=1 AK4 jets w/ pt>200 |eta|<2.4
+ *     * MET > 50 GeV
+ *     * MET+lepton.pt > 150 GeV
+ *     * lepton-2D-cut [DR>0.4 || pTrel>25 GeV] (wrt AK4 jets w/ pt>25 GeV)
+ *     * (electron-only) triangular cuts
+ *   * perform ttbar kinematical reconstruction (hyps stored in output ntuple)
+ *
+ * -- ITEMS TO BE IMPLEMENTED:
+ *   * primary vertex selection
+ *   * JER smearing for TopJet collection
+ *   * update 2D cut values (after validation)
+ *
+ */
 using namespace uhh2;
 
 class ZprimeSelectionModule: public AnalysisModule {
@@ -41,6 +53,9 @@ class ZprimeSelectionModule: public AnalysisModule {
   virtual bool process(Event & event) override;
 
  private:    
+  Event::Handle<int> h_flag_toptagevent;
+
+  // cleaners
   std::unique_ptr<MuonCleaner> muo_cleaner;
   std::unique_ptr<ElectronCleaner> ele_cleaner;
   std::unique_ptr<JetCorrector> jet_corrector;
@@ -53,21 +68,42 @@ class ZprimeSelectionModule: public AnalysisModule {
 //  std::unique_ptr<TopJetResolutionSmearer> topjetER_smearer;
   std::unique_ptr<TopJetCleaner> topjet_cleaner;
 
-  std::vector<std::unique_ptr<AnalysisModule>> recomodules;
-
-  // Selection
-  std::unique_ptr<AndSelection> lepN_sel;
-  std::unique_ptr<Selection> jet1_sel, jet2_sel, htlep_sel, met_sel, twodcut_sel, toptagevent_sel;
+  // selections
   std::unique_ptr<Selection> trigger_sel;
-  // Hists
-  std::unique_ptr<Hists> input_h_event, lep1_h_event, jet1_h_event, jet2_h_event, trigger_h_event;
-  std::unique_ptr<Hists> htlep_h_event, met_h_event, twodcut_h_event, toptagevent_h_event;
-  std::unique_ptr<Hists> h_hyphists, h_event, h_jet, h_ele, h_mu, h_topjet;
-  uhh2::Event::Handle<std::vector<ReconstructionHypothesis>> h_hyps;
+  std::unique_ptr<AndSelection> lep1_sel;
+  std::unique_ptr<Selection> jet2_sel;
+  std::unique_ptr<Selection> jet1_sel;
+  std::unique_ptr<Selection> met_sel;
+  std::unique_ptr<Selection> htlep_sel;
+  std::unique_ptr<Selection> twodcut_sel;
+  std::unique_ptr<Selection> triangc_sel;
+  std::unique_ptr<Selection> toptagevent_sel;
+
+  // ttbar reconstruction
+  std::unique_ptr<AnalysisModule> ttgenprod;
+  std::unique_ptr<AnalysisModule> reco_primlep;
+  std::unique_ptr<AnalysisModule> ttbar_reco_toptag0, ttbar_reco_toptag1;
+  std::unique_ptr<AnalysisModule> ttbar_chi2min;
+  Event::Handle<std::vector<ReconstructionHypothesis>> h_ttbar_hyps;
+
+  // hists
+  std::unique_ptr<Hists> input_h;
+  std::unique_ptr<Hists> trigger_h;
+  std::unique_ptr<Hists> lep1_h;
+  std::unique_ptr<Hists> jet2_h;
+  std::unique_ptr<Hists> jet1_h;
+  std::unique_ptr<Hists> met_h;
+  std::unique_ptr<Hists> htlep_h;
+  std::unique_ptr<Hists> twodcut_h;
+  std::unique_ptr<Hists> triangc_h;
+  std::unique_ptr<Hists> toptagevent_h;
+  std::unique_ptr<Hists> chi2min_toptag0_h;
+  std::unique_ptr<Hists> chi2min_toptag1_h;
 };
 
 ZprimeSelectionModule::ZprimeSelectionModule(Context & ctx){
 
+  //// OBJ CLEANING
   muo_cleaner.reset(new MuonCleaner(AndId<Muon>(MuonIDTight(), PtEtaCut(45., 2.1))));
   ele_cleaner.reset(new ElectronCleaner(AndId<Electron>(ElectronID_PHYS14_25ns_tight_noIso, PtEtaCut(50., 2.5))));
   jet_corrector.reset(new JetCorrector(JERFiles::PHYS14_L123_MC));
@@ -80,85 +116,108 @@ ZprimeSelectionModule::ZprimeSelectionModule(Context & ctx){
   topjetlepton_cleaner.reset(new TopJetLeptonDeltaRCleaner(.8));
 //  topjetER_smearer.reset(new TopJetResolutionSmearer(ctx));
   topjet_cleaner.reset(new TopJetCleaner(TopJetId(PtEtaCut(400., 2.4))));
+  ////
 
+  //// EVENT SELECTION
   bool muon(false), elec(false);
   const std::string channel(ctx.get("channel", ""));
-  const std::string triggername(ctx.get("triggername","NotSet"));
+  const std::string triggername(ctx.get("triggername", "NotSet"));
   if(channel == "muon") muon = true;
   else if(channel == "electron") elec = true;
   else throw std::runtime_error("undefined argument for 'channel' key in xml file (must be 'muon' or 'electron'): "+channel);
 
-  lepN_sel.reset(new AndSelection(ctx));
+  lep1_sel.reset(new AndSelection(ctx));
   if(muon){
-    lepN_sel->add<NMuonSelection>("muoN == 1", 1, 1);
-    lepN_sel->add<NElectronSelection>("eleN == 0", 0, 0);
-    if(triggername=="NotSet")
-      trigger_sel = make_unique<TriggerSelection>("HLT_Mu40_eta2p1_PFJet200_PFJet50_v*");
-    else 
-      trigger_sel = make_unique<TriggerSelection>(triggername);
+    lep1_sel->add<NMuonSelection>("muoN == 1", 1, 1);
+    lep1_sel->add<NElectronSelection>("eleN == 0", 0, 0);
+
+    if(triggername != "NotSet") trigger_sel = make_unique<TriggerSelection>(triggername);
+    else trigger_sel = make_unique<TriggerSelection>("HLT_Mu40_eta2p1_PFJet200_PFJet50_v*");
   }
   else if(elec){
-    lepN_sel->add<NMuonSelection>("muoN == 0", 0, 0);
-    lepN_sel->add<NElectronSelection>("eleN == 1", 1, 1);
-    if(triggername=="NotSet")
-      trigger_sel = make_unique<TriggerSelection>("HLT_Ele45_CaloIdVT_GsfTrkIdT_PFJet200_PFJet50_v*");
-    else
-      trigger_sel = make_unique<TriggerSelection>(triggername); 
+    lep1_sel->add<NMuonSelection>("muoN == 0", 0, 0);
+    lep1_sel->add<NElectronSelection>("eleN == 1", 1, 1);
+
+    if(triggername != "NotSet") trigger_sel = make_unique<TriggerSelection>(triggername);
+    else trigger_sel = make_unique<TriggerSelection>("HLT_Ele45_CaloIdVT_GsfTrkIdT_PFJet200_PFJet50_v*");
   }
 
-  jet1_sel.reset(new NJetSelection(1, -1, JetId(PtEtaCut(200., 2.4)))); // at least 1 jet with pt>200 and |eta|<2.4
-  jet2_sel.reset(new NJetSelection(2, -1, JetId(PtEtaCut(50., 2.4))));  // at least 2 jets with pt>50 and |eta|<2.4
+  jet2_sel.reset(new NJetSelection(2, -1, JetId(PtEtaCut( 50., 2.4))));
+  jet1_sel.reset(new NJetSelection(1, -1, JetId(PtEtaCut(200., 2.4))));
   met_sel.reset(new METCut(50., std::numeric_limits<double>::infinity()));
   htlep_sel.reset(new HTlepCut(150., std::numeric_limits<double>::infinity()));
   twodcut_sel.reset(new TwoDCut(.4, 25.));
-  toptagevent_sel.reset(new TopTagEventSelection(CMSTopTag(), 1.2));
 
-  // reconstruction hypotheses
-  recomodules.emplace_back(new PrimaryLepton(ctx));
-  recomodules.emplace_back(new HighMassTTbarReconstruction(ctx,NeutrinoReconstruction));
-  recomodules.emplace_back(new Chi2Discriminator(ctx,"HighMassReconstruction"));
+  if(elec) triangc_sel.reset(new TriangularCuts(1.5, 75.));
+  else if(muon) triangc_sel.reset(new AndSelection(ctx)); // always true (no triangular cuts for muon channel)
 
-  // Hists setup
-  input_h_event.reset(new EventHists(ctx, "input_Event"));
-  lep1_h_event.reset(new EventHists(ctx, "lep1_Event"));
-  jet1_h_event.reset(new EventHists(ctx, "jet1_Event"));
-  jet2_h_event.reset(new EventHists(ctx, "jet2_Event"));
-  met_h_event.reset(new EventHists(ctx, "met_Event"));
-  htlep_h_event.reset(new EventHists(ctx, "htlep_Event"));
-  twodcut_h_event.reset(new EventHists(ctx, "twodcut_Event"));
-  toptagevent_h_event.reset(new EventHists(ctx, "toptagevent_Event"));
-  trigger_h_event.reset(new EventHists(ctx,"trigger_Event"));
-  h_hyphists.reset(new HypothesisHists(ctx, "Chi2Hists", "HighMassReconstruction", "Chi2"));
-  h_hyps = ctx.get_handle<std::vector<ReconstructionHypothesis>>("HighMassReconstruction");
-  h_event.reset(new EventHists(ctx, "Event_Sel"));
-  h_jet.reset(new JetHists(ctx, "Jets_Sel"));
-  h_ele.reset(new ElectronHists(ctx, "Electron_Sel"));
-  h_mu.reset(new MuonHists(ctx, "Muon_Sel"));
-  h_topjet.reset(new TopJetHists(ctx, "TopJets_Sel"));
+  const TopJetId topjetID = CMSTopTag();
+  const float minDR_topjet_jet(1.2);
+
+  toptagevent_sel.reset(new TopTagEventSelection(topjetID, minDR_topjet_jet));
+  h_flag_toptagevent = ctx.declare_event_output<int>("flag_toptagevent");
+  ////
+
+  //// TTBAR KINEMATICAL RECO
+  ttgenprod.reset(new TTbarGenProducer(ctx, "ttbargen", false));
+
+  reco_primlep.reset(new PrimaryLepton(ctx));
+
+  std::string ttbar_hyps_label("TTbarReconstruction");
+  ttbar_reco_toptag0.reset(new HighMassTTbarReconstruction(ctx, NeutrinoReconstruction, ttbar_hyps_label));
+  ttbar_reco_toptag1.reset(new TopTagReconstruction(ctx, NeutrinoReconstruction, ttbar_hyps_label, topjetID, minDR_topjet_jet));
+  ttbar_chi2min.reset(new Chi2Discriminator(ctx, ttbar_hyps_label));
+  h_ttbar_hyps = ctx.get_handle<std::vector<ReconstructionHypothesis>>(ttbar_hyps_label);
+  ////
+
+  //// HISTS
+  input_h.reset(new ZprimeSelectionHists(ctx, "input"));
+  trigger_h.reset(new ZprimeSelectionHists(ctx, "trigger"));
+  lep1_h.reset(new ZprimeSelectionHists(ctx, "lep1"));
+  jet2_h.reset(new ZprimeSelectionHists(ctx, "jet2"));
+  jet1_h.reset(new ZprimeSelectionHists(ctx, "jet1"));
+  met_h.reset(new ZprimeSelectionHists(ctx, "met"));
+  htlep_h.reset(new ZprimeSelectionHists(ctx, "htlep"));
+  twodcut_h.reset(new ZprimeSelectionHists(ctx, "twodcut"));
+  triangc_h.reset(new ZprimeSelectionHists(ctx, "triangc"));
+  toptagevent_h.reset(new ZprimeSelectionHists(ctx, "toptagevent"));
+  chi2min_toptag0_h.reset(new HypothesisHists(ctx, "chi2min_toptag0__HypHists", ttbar_hyps_label, "Chi2"));
+  chi2min_toptag1_h.reset(new HypothesisHists(ctx, "chi2min_toptag1__HypHists", ttbar_hyps_label, "Chi2"));
+  ////
 }
 
 bool ZprimeSelectionModule::process(Event & event){
 
-  input_h_event->fill(event);
+  input_h->fill(event);
 
+  //// HLT selection
+  bool pass_trigger = trigger_sel->passes(event);
+  if(!pass_trigger) return false;
+  trigger_h->fill(event);
+  ////
+
+  //// LEPTON selection
   muo_cleaner->process(event);
-  ele_cleaner->process(event);
-  bool pass_lepN = lepN_sel->passes(event);
-  if(!pass_lepN) return false;
-  lep1_h_event->fill(event);
+  sort_by_pt<Muon>(*event.muons);
 
+  ele_cleaner->process(event);
+  sort_by_pt<Electron>(*event.electrons);
+
+  bool pass_lep1 = lep1_sel->passes(event);
+  if(!pass_lep1) return false;
+  lep1_h->fill(event);
+  ////
+
+  //// JET selection
   jet_corrector->process(event);
   jetlepton_cleaner->process(event);
   jetER_smearer->process(event);
+
+  /* lepton-2Dcut boolean */
   jet_cleaner1->process(event); // jets w/ pt>25 GeV for lepton-2Dcut
-  //Trigger selection
-  bool trigger_selection = trigger_sel->passes(event);
-  if(!trigger_selection) return false;
-  trigger_h_event->fill(event);
-  // 2D cut
   bool pass_twodcut = twodcut_sel->passes(event);
 
-  jet_cleaner2->process(event); // cleaned jets with pt>50 GeV & |eta|<2.4
+  jet_cleaner2->process(event);
   sort_by_pt<Jet>(*event.jets);
 
   topjet_corrector->process(event);
@@ -167,41 +226,63 @@ bool ZprimeSelectionModule::process(Event & event){
   topjet_cleaner->process(event);
   sort_by_pt<TopJet>(*event.topjets);
 
-  // selection on 1st AK4 jet
-  bool pass_jet1 = jet1_sel->passes(event);
-  if(!pass_jet1) return false;
-  jet1_h_event->fill(event);
-
-  // selection on 2nd AK4 jet
+  /* 2nd AK4 jet selection */
   bool pass_jet2 = jet2_sel->passes(event);
   if(!pass_jet2) return false;
-  jet2_h_event->fill(event);
+  jet2_h->fill(event);
 
-  // selection on MET
+  /* 1st AK4 jet selection */
+  bool pass_jet1 = jet1_sel->passes(event);
+  if(!pass_jet1) return false;
+  jet1_h->fill(event);
+  ////
+
+  //// MET selection
   bool pass_met = met_sel->passes(event);
   if(!pass_met) return false;
-  met_h_event->fill(event);
+  met_h->fill(event);
 
-  // selection on HT_lep
+  /* HT_lep selection */
   bool pass_htlep = htlep_sel->passes(event);
   if(!pass_htlep) return false;
-  htlep_h_event->fill(event);
+  htlep_h->fill(event);
+  ////
 
-  // selection on lepton-2Dcut
+  //// LEPTON-2Dcut selection
   if(!pass_twodcut) return false;
-  twodcut_h_event->fill(event);
+  twodcut_h->fill(event);
+  ////
 
-  // selection for 'top-tagged jet event'
+  //// TRIANGULAR-CUTS selection (electron-only)
+  bool pass_triangc = triangc_sel->passes(event);
+  if(!pass_triangc) return false;
+  triangc_h->fill(event);
+  ////
+
+  //// TOPTAG-EVENT selection
   bool pass_toptagevent = toptagevent_sel->passes(event);
-  if(pass_toptagevent) toptagevent_h_event->fill(event);
+  if(pass_toptagevent) toptagevent_h->fill(event);
 
-  for(auto & m : recomodules) m->process(event);
-  h_event->fill(event);
-  h_jet->fill(event);
-  h_ele->fill(event);
-  h_mu->fill(event);
-  h_topjet->fill(event);
-  h_hyphists->fill(event);
+  /* add flag_toptagevent to output ntuple */
+  event.set(h_flag_toptagevent, int(pass_toptagevent));
+  ////
+
+  //// TTBAR KIN RECO
+  ttgenprod->process(event);
+
+  reco_primlep->process(event);
+
+  if(pass_toptagevent){
+    ttbar_reco_toptag1->process(event);
+    ttbar_chi2min->process(event);
+    chi2min_toptag1_h->fill(event);
+  }
+  else{
+    ttbar_reco_toptag0->process(event);
+    ttbar_chi2min->process(event);
+    chi2min_toptag0_h->fill(event);
+  }
+  ////
 
   return true;
 }

--- a/src/ZprimeSelectionModule.cxx
+++ b/src/ZprimeSelectionModule.cxx
@@ -111,7 +111,7 @@ ZprimeSelectionModule::ZprimeSelectionModule(Context & ctx){
   jetlepton_cleaner->set_drmax(.4);
   jetER_smearer.reset(new JetResolutionSmearer(ctx));
   jet_cleaner1.reset(new JetCleaner(25., std::numeric_limits<double>::infinity())); 
-  jet_cleaner2.reset(new JetCleaner(50., 2.4));
+  jet_cleaner2.reset(new JetCleaner(30., 2.4));
   topjet_corrector.reset(new TopJetCorrector(JERFiles::PHYS14_L123_MC));
   topjetlepton_cleaner.reset(new TopJetLeptonDeltaRCleaner(.8));
 //  topjetER_smearer.reset(new TopJetResolutionSmearer(ctx));

--- a/src/ZprimeSelectionModule.cxx
+++ b/src/ZprimeSelectionModule.cxx
@@ -151,7 +151,7 @@ ZprimeSelectionModule::ZprimeSelectionModule(Context & ctx){
   if(elec) triangc_sel.reset(new TriangularCuts(1.5, 75.));
   else if(muon) triangc_sel.reset(new AndSelection(ctx)); // always true (no triangular cuts for muon channel)
 
-  const TopJetId topjetID = CMSTopTag();
+  const TopJetId topjetID = AndId<TopJet>(CMSTopTag(), Tau32());
   const float minDR_topjet_jet(1.2);
 
   toptagevent_sel.reset(new TopTagEventSelection(topjetID, minDR_topjet_jet));


### PR DESCRIPTION
caveat: these updates have been developed and tested in the "next-ntuple-format" branch of UHH2/ and they require the recent update of the TTbarReconstruction methods in UHH2/common/. as a consequence, these updates work with commit "36bef06..." of UHH2/.

* most updates are for the selection module
 * added triangular cuts for electron channel
 * added chi2 reconstruction, distinguishing between events w/ and w/o a top-tagged jet (as it was done in UHHAnalysis/)
 * cutflow at the selection level should now be complete
 * updated histogram content in selection module, using ZprimeSelectionHists class

* updated electron.pt cut in preselection module (>30 GeV --> >50 GeV):
 * now consistent with selection (electron.pt cut in preselection affects jet-lepton cleaning, so the jet multiplicity, and thus the preselection decision to keep or not the event)

