### PR TITLE
updated chi2 for ttag events; updated files in config/;

### DIFF
--- a/config/ZprimePostSelection_ELEC.xml
+++ b/config/ZprimePostSelection_ELEC.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd" [
 
   <!ENTITY PROOFdir  "/nfs/dust/cms/user/missirol/PROOF">
-  <!ENTITY SELdir    "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/selection/150312_test/elec/">
-  <!ENTITY POSELdir  "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/postselection/150312_test/elec/">
+  <!ENTITY SELdir    "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/selection/150430_test/elec/">
+  <!ENTITY POSELdir  "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/postselection/150430_test/elec/">
 ]>
 
 <JobConfiguration JobName="ZprimePostSelectionJob" OutputLevel="INFO">
@@ -35,11 +35,32 @@
             <OutputTree Name="AnalysisTree" />
         </InputData>
 
+<!--
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP1000w100" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.ZP1000w100.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP2000w200" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.ZP2000w200.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP3000w300" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.ZP3000w300.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+-->
+
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="TTbar" Cacheable="False">
             <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.TTbar.root" Lumi="0.0"/>
             <InputTree Name="AnalysisTree" />
             <OutputTree Name="AnalysisTree" />
         </InputData>
+
 
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets" Cacheable="False">
             <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.WJets.root" Lumi="0.0"/>
@@ -47,8 +68,138 @@
             <OutputTree Name="AnalysisTree" />
         </InputData>
 
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT100to200" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.WJets_HT100to200.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT200to400" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.WJets_HT200to400.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT400to600" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.WJets_HT400to600.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT600toINF" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.WJets_HT600toINF.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="T_s" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.T_s.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="T_t" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.T_t.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="T_tW" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.T_tW.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="Tbar_s" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.Tbar_s.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="Tbar_t" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.Tbar_t.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="Tbar_tW" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.Tbar_tW.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets" Cacheable="False">
             <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.ZJets.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets_HT100to200" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.ZJets_HT100to200.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets_HT200to400" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.ZJets_HT200to400.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets_HT400to600" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.ZJets_HT400to600.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets_HT600toINF" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.ZJets_HT600toINF.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+<!--
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WW" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.WW.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WZ" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.WZ.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZZ" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.ZZ.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+-->
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="QCD_HT100to250" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.QCD_HT100to250.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="QCD_HT250to500" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.QCD_HT250to500.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="QCD_HT500to1000" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.QCD_HT500to1000.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="QCD_HT1000toINF" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.QCD_HT1000toINF.root" Lumi="0.0"/>
             <InputTree Name="AnalysisTree" />
             <OutputTree Name="AnalysisTree" />
         </InputData>

--- a/config/ZprimePostSelection_MUON.xml
+++ b/config/ZprimePostSelection_MUON.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd" [
 
   <!ENTITY PROOFdir  "/nfs/dust/cms/user/missirol/PROOF">
-  <!ENTITY SELdir    "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/selection/150312_test/muon/">
-  <!ENTITY POSELdir  "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/postselection/150312_test/muon/">
+  <!ENTITY SELdir    "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/selection/150430_test/muon/">
+  <!ENTITY POSELdir  "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/postselection/150430_test/muon/">
 ]>
 
 <JobConfiguration JobName="ZprimePostSelectionJob" OutputLevel="INFO">
@@ -35,11 +35,32 @@
             <OutputTree Name="AnalysisTree" />
         </InputData>
 
+<!--
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP1000w100" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.ZP1000w100.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP2000w200" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.ZP2000w200.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP3000w300" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.ZP3000w300.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+-->
+
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="TTbar" Cacheable="False">
             <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.TTbar.root" Lumi="0.0"/>
             <InputTree Name="AnalysisTree" />
             <OutputTree Name="AnalysisTree" />
         </InputData>
+
 
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets" Cacheable="False">
             <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.WJets.root" Lumi="0.0"/>
@@ -47,8 +68,138 @@
             <OutputTree Name="AnalysisTree" />
         </InputData>
 
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT100to200" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.WJets_HT100to200.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT200to400" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.WJets_HT200to400.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT400to600" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.WJets_HT400to600.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT600toINF" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.WJets_HT600toINF.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="T_s" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.T_s.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="T_t" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.T_t.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="T_tW" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.T_tW.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="Tbar_s" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.Tbar_s.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="Tbar_t" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.Tbar_t.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="Tbar_tW" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.Tbar_tW.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets" Cacheable="False">
             <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.ZJets.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets_HT100to200" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.ZJets_HT100to200.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets_HT200to400" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.ZJets_HT200to400.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets_HT400to600" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.ZJets_HT400to600.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets_HT600toINF" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.ZJets_HT600toINF.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+<!--
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WW" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.WW.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WZ" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.WZ.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZZ" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.ZZ.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+-->
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="QCD_HT100to250" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.QCD_HT100to250.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="QCD_HT250to500" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.QCD_HT250to500.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="QCD_HT500to1000" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.QCD_HT500to1000.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="QCD_HT1000toINF" Cacheable="False">
+            <In FileName="&SELdir;/uhh2.AnalysisModuleRunner.MC.QCD_HT1000toINF.root" Lumi="0.0"/>
             <InputTree Name="AnalysisTree" />
             <OutputTree Name="AnalysisTree" />
         </InputData>

--- a/config/ZprimePreSelection.xml
+++ b/config/ZprimePreSelection.xml
@@ -1,15 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd" [
 
+  <!ENTITY NEVT "-1">
+
   <!ENTITY PROOFdir  "/nfs/dust/cms/user/missirol/PROOF">
-  <!ENTITY PRESELdir "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/preselection">
+  <!ENTITY PRESELdir "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/preselection/150430_test">
 
   <!ENTITY ZP1000w10 SYSTEM "../../common/datasets/MC_Zp_TTJets_M1000W10_20x25.xml">
   <!ENTITY ZP2000w20 SYSTEM "../../common/datasets/MC_Zp_TTJets_M2000W20_20x25.xml">
   <!ENTITY ZP3000w30 SYSTEM "../../common/datasets/MC_Zp_TTJets_M3000W30_20x25.xml">
-  <!ENTITY TTbar     SYSTEM "../../common/datasets/MC_TTJets_20x25.xml">
-  <!ENTITY WJets     SYSTEM "../../common/datasets/MC_WJets_LNu_20x25.xml">
-  <!ENTITY ZJets     SYSTEM "../../common/datasets/MC_ZJets_LL_20x25.xml">
+
+  <!ENTITY ZP1000w100 SYSTEM "../../common/datasets/MC_Zp_TTJets_M1000W100_20x25.xml">
+  <!ENTITY ZP2000w200 SYSTEM "../../common/datasets/MC_Zp_TTJets_M2000W200_20x25.xml">
+  <!ENTITY ZP3000w300 SYSTEM "../../common/datasets/MC_Zp_TTJets_M3000W300_20x25.xml">
+
+  <!ENTITY TTbar            SYSTEM "../../common/datasets/MC_TTJets_20x25.xml">
+
+  <!ENTITY WJets            SYSTEM "../../common/datasets/MC_WJets_LNu_20x25.xml">
+  <!ENTITY WJets_HT100to200 SYSTEM "../../common/datasets/MC_WJets_LNu_HT100to200_20x25.xml">
+  <!ENTITY WJets_HT200to400 SYSTEM "../../common/datasets/MC_WJets_LNu_HT200to400_20x25.xml">
+  <!ENTITY WJets_HT400to600 SYSTEM "../../common/datasets/MC_WJets_LNu_HT400to600_20x25.xml">
+  <!ENTITY WJets_HT600toINF SYSTEM "../../common/datasets/MC_WJets_LNu_HT600toInf_20x25.xml">
+
+  <!ENTITY T_s              SYSTEM "../../common/datasets/MC_TToLeptons_s-channel_20x25.xml">
+  <!ENTITY T_t              SYSTEM "../../common/datasets/MC_TToLeptons_t-channel_20x25.xml">
+  <!ENTITY T_tW             SYSTEM "../../common/datasets/MC_T_tW_20x25.xml">
+  <!ENTITY Tbar_s           SYSTEM "../../common/datasets/MC_TBarToLeptons_s-channel_20x25.xml">
+  <!ENTITY Tbar_t           SYSTEM "../../common/datasets/MC_TBarToLeptons_t-channel_20x25.xml">
+  <!ENTITY Tbar_tW          SYSTEM "../../common/datasets/MC_Tbar_tW_20x25.xml">
+
+  <!ENTITY ZJets            SYSTEM "../../common/datasets/MC_ZJets_LL_20x25.xml">
+  <!ENTITY ZJets_HT100to200 SYSTEM "../../common/datasets/MC_ZJets_LL_HT100to200_20x25.xml">
+  <!ENTITY ZJets_HT200to400 SYSTEM "../../common/datasets/MC_ZJets_LL_HT200to400_20x25.xml">
+  <!ENTITY ZJets_HT400to600 SYSTEM "../../common/datasets/MC_ZJets_LL_HT400to600_20x25.xml">
+  <!ENTITY ZJets_HT600toINF SYSTEM "../../common/datasets/MC_ZJets_LL_HT600toInf_20x25.xml">
+
+  <!ENTITY QCD_HT100to250       SYSTEM "../../common/datasets/MC_QCD_HT100To250_20x25.xml">
+  <!ENTITY QCD_HT250to500       SYSTEM "../../common/datasets/MC_QCD_HT250To500_20x25.xml">
+  <!ENTITY QCD_HT250to500_ext1  SYSTEM "../../common/datasets/MC_QCD_HT250To500_20x25_ext1.xml">
+  <!ENTITY QCD_HT500to1000      SYSTEM "../../common/datasets/MC_QCD_HT500To1000_20x25.xml">
+  <!ENTITY QCD_HT500to1000_ext1 SYSTEM "../../common/datasets/MC_QCD_HT500To1000_20x25_ext1.xml">
+  <!ENTITY QCD_HT1000toINF      SYSTEM "../../common/datasets/MC_QCD_HT1000ToInf_20x25.xml">
+  <!ENTITY QCD_HT1000toINF_ext1 SYSTEM "../../common/datasets/MC_QCD_HT1000ToInf_20x25_ext1.xml">
+
 ]>
 
 <JobConfiguration JobName="ZprimePreSelectionJob" OutputLevel="INFO">
@@ -23,101 +56,194 @@
     <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&PRESELdir;/" PostFix="" TargetLumi="1" RunMode="PROOF" ProofServer="pod://" ProofWorkDir="&PROOFdir;/" >
 -->
 
-
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP1000w10" Cacheable="True">
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="ZP1000w10" Cacheable="False">
           &ZP1000w10;
           <InputTree Name="AnalysisTree" />
           <OutputTree Name="AnalysisTree" />
         </InputData>
 
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP2000w20" Cacheable="True">
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="ZP2000w20" Cacheable="False">
           &ZP2000w20;
           <InputTree Name="AnalysisTree" />
           <OutputTree Name="AnalysisTree" />
         </InputData>
 
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP3000w30" Cacheable="True">
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="ZP3000w30" Cacheable="False">
           &ZP3000w30;
           <InputTree Name="AnalysisTree" />
           <OutputTree Name="AnalysisTree" />
         </InputData>
+
 <!--
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP1000w100" Cacheable="True">
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="ZP1000w100" Cacheable="False">
           &ZP1000w100;
           <InputTree Name="AnalysisTree" />
-	  <OutputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
         </InputData>
 
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP2000w200" Cacheable="True">
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="ZP2000w200" Cacheable="False">
           &ZP2000w200;
           <InputTree Name="AnalysisTree" />
-	  <OutputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
         </InputData>
 
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP3000w300" Cacheable="True">
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="ZP3000w300" Cacheable="False">
           &ZP3000w300;
           <InputTree Name="AnalysisTree" />
-	  <OutputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
         </InputData>
 -->
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="TTbar" Cacheable="True">
+
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="TTbar" Cacheable="False">
           &TTbar;
           <InputTree Name="AnalysisTree" />
-	  <OutputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
         </InputData>
 
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets" Cacheable="True">
+
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="WJets" Cacheable="False">
           &WJets;
           <InputTree Name="AnalysisTree" />
-	  <OutputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
         </InputData>
-<!--
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT100to200" Cacheable="True">
+
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="WJets_HT100to200" Cacheable="False">
           &WJets_HT100to200;
           <InputTree Name="AnalysisTree" />
-	  <OutputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
         </InputData>
 
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT200to400" Cacheable="True">
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="WJets_HT200to400" Cacheable="False">
           &WJets_HT200to400;
           <InputTree Name="AnalysisTree" />
-	  <OutputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
         </InputData>
 
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT400to600" Cacheable="True">
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="WJets_HT400to600" Cacheable="False">
           &WJets_HT400to600;
           <InputTree Name="AnalysisTree" />
-	  <OutputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
         </InputData>
 
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT600toInf" Cacheable="True">
-          &WJets_HT600toInf;
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="WJets_HT600toINF" Cacheable="False">
+          &WJets_HT600toINF;
           <InputTree Name="AnalysisTree" />
-	  <OutputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
         </InputData>
 
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WW" Cacheable="True">
+
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="T_s" Cacheable="False">
+          &T_s;
+          <InputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="T_t" Cacheable="False">
+          &T_t;
+          <InputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="T_tW" Cacheable="False">
+          &T_tW;
+          <InputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="Tbar_s" Cacheable="False">
+          &Tbar_s;
+          <InputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="Tbar_t" Cacheable="False">
+          &Tbar_t;
+          <InputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="Tbar_tW" Cacheable="False">
+          &Tbar_tW;
+          <InputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+<!--
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="WW" Cacheable="False">
           &WW;
           <InputTree Name="AnalysisTree" />
-	  <OutputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
         </InputData>
 
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WZ" Cacheable="True">
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="WZ" Cacheable="False">
           &WZ;
           <InputTree Name="AnalysisTree" />
-	  <OutputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
         </InputData>
 
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZZ" Cacheable="True">
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="ZZ" Cacheable="False">
           &ZZ;
           <InputTree Name="AnalysisTree" />
-	  <OutputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
         </InputData>
 -->
-        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets" Cacheable="True">
+
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="ZJets" Cacheable="False">
           &ZJets;
           <InputTree Name="AnalysisTree" />
-	  <OutputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="ZJets_HT100to200" Cacheable="False">
+          &ZJets_HT100to200;
+          <InputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="ZJets_HT200to400" Cacheable="False">
+          &ZJets_HT200to400;
+          <InputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="ZJets_HT400to600" Cacheable="False">
+          &ZJets_HT400to600;
+          <InputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="ZJets_HT600toINF" Cacheable="False">
+          &ZJets_HT600toINF;
+          <InputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="QCD_HT100to250" Cacheable="False">
+          &QCD_HT100to250;
+          <InputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="QCD_HT250to500" Cacheable="False">
+          &QCD_HT250to500;
+          &QCD_HT250to500_ext1;
+          <InputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="QCD_HT500to1000" Cacheable="False">
+          &QCD_HT500to1000;
+          &QCD_HT500to1000_ext1;
+          <InputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="QCD_HT1000toINF" Cacheable="False">
+          &QCD_HT1000toINF;
+          &QCD_HT1000toINF_ext1;
+          <InputTree Name="AnalysisTree" />
+          <OutputTree Name="AnalysisTree" />
         </InputData>
 
 
@@ -131,6 +257,8 @@
             <Item Name="METName" Value="slimmedMETs" />
             <Item Name="TopJetCollection" Value="patJetsCmsTopTagCHSPacked" />
             <Item Name="GenParticleCollection" Value="GenParticles" />
+
+            <Item Name="use_sframe_weight" Value="false" />
 
             <Item Name="channel" Value="lepton" />
 

--- a/config/ZprimeSelection_ELEC.xml
+++ b/config/ZprimeSelection_ELEC.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd" [
 
   <!ENTITY PROOFdir  "/nfs/dust/cms/user/missirol/PROOF">
-  <!ENTITY PRESELdir "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/preselection">
-  <!ENTITY SELdir    "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/selection/150312_test/elec/">
+  <!ENTITY PRESELdir "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/preselection/150430_test/">
+  <!ENTITY SELdir    "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/selection/150430_test/elec/">
 ]>
 
 <JobConfiguration JobName="ZprimeSelectionJob" OutputLevel="INFO">
@@ -35,11 +35,32 @@
             <OutputTree Name="AnalysisTree" />
         </InputData>
 
+<!--
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP1000w100" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZP1000w100.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP2000w200" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZP2000w200.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP3000w300" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZP3000w300.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+-->
+
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="TTbar" Cacheable="False">
             <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.TTbar.root" Lumi="0.0"/>
             <InputTree Name="AnalysisTree" />
             <OutputTree Name="AnalysisTree" />
         </InputData>
+
 
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets" Cacheable="False">
             <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.WJets.root" Lumi="0.0"/>
@@ -47,8 +68,138 @@
             <OutputTree Name="AnalysisTree" />
         </InputData>
 
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT100to200" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.WJets_HT100to200.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT200to400" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.WJets_HT200to400.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT400to600" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.WJets_HT400to600.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT600toINF" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.WJets_HT600toINF.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="T_s" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.T_s.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="T_t" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.T_t.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="T_tW" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.T_tW.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="Tbar_s" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.Tbar_s.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="Tbar_t" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.Tbar_t.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="Tbar_tW" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.Tbar_tW.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets" Cacheable="False">
             <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZJets.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets_HT100to200" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZJets_HT100to200.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets_HT200to400" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZJets_HT200to400.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets_HT400to600" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZJets_HT400to600.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets_HT600toINF" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZJets_HT600toINF.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+<!--
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WW" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.WW.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WZ" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.WZ.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZZ" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZZ.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+-->
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="QCD_HT100to250" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.QCD_HT100to250.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="QCD_HT250to500" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.QCD_HT250to500.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="QCD_HT500to1000" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.QCD_HT500to1000.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="QCD_HT1000toINF" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.QCD_HT1000toINF.root" Lumi="0.0"/>
             <InputTree Name="AnalysisTree" />
             <OutputTree Name="AnalysisTree" />
         </InputData>

--- a/config/ZprimeSelection_MUON.xml
+++ b/config/ZprimeSelection_MUON.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd" [
 
   <!ENTITY PROOFdir  "/nfs/dust/cms/user/missirol/PROOF">
-  <!ENTITY PRESELdir "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/preselection">
-  <!ENTITY SELdir    "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/selection/150312_test/muon/">
+  <!ENTITY PRESELdir "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/preselection/150430_test/">
+  <!ENTITY SELdir    "/nfs/dust/cms/user/missirol/Analysis7XY/ttbar_semilep_13TeV/selection/150430_test/muon/">
 ]>
 
 <JobConfiguration JobName="ZprimeSelectionJob" OutputLevel="INFO">
@@ -35,11 +35,32 @@
             <OutputTree Name="AnalysisTree" />
         </InputData>
 
+<!--
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP1000w100" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZP1000w100.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP2000w200" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZP2000w200.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZP3000w300" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZP3000w300.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+-->
+
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="TTbar" Cacheable="False">
             <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.TTbar.root" Lumi="0.0"/>
             <InputTree Name="AnalysisTree" />
             <OutputTree Name="AnalysisTree" />
         </InputData>
+
 
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets" Cacheable="False">
             <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.WJets.root" Lumi="0.0"/>
@@ -47,8 +68,138 @@
             <OutputTree Name="AnalysisTree" />
         </InputData>
 
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT100to200" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.WJets_HT100to200.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT200to400" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.WJets_HT200to400.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT400to600" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.WJets_HT400to600.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WJets_HT600toINF" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.WJets_HT600toINF.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="T_s" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.T_s.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="T_t" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.T_t.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="T_tW" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.T_tW.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="Tbar_s" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.Tbar_s.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="Tbar_t" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.Tbar_t.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="Tbar_tW" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.Tbar_tW.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+
         <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets" Cacheable="False">
             <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZJets.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets_HT100to200" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZJets_HT100to200.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets_HT200to400" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZJets_HT200to400.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets_HT400to600" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZJets_HT400to600.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZJets_HT600toINF" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZJets_HT600toINF.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+<!--
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WW" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.WW.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="WZ" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.WZ.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="ZZ" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.ZZ.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+-->
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="QCD_HT100to250" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.QCD_HT100to250.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="QCD_HT250to500" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.QCD_HT250to500.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="QCD_HT500to1000" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.QCD_HT500to1000.root" Lumi="0.0"/>
+            <InputTree Name="AnalysisTree" />
+            <OutputTree Name="AnalysisTree" />
+        </InputData>
+
+        <InputData Lumi="1" NEventsMax="-1" Type="MC" Version="QCD_HT1000toINF" Cacheable="False">
+            <In FileName="&PRESELdir;/uhh2.AnalysisModuleRunner.MC.QCD_HT1000toINF.root" Lumi="0.0"/>
             <InputTree Name="AnalysisTree" />
             <OutputTree Name="AnalysisTree" />
         </InputData>

--- a/src/ZprimePreSelectionModule.cxx
+++ b/src/ZprimePreSelectionModule.cxx
@@ -63,7 +63,7 @@ ZprimePreSelectionModule::ZprimePreSelectionModule(Context & ctx){
 
   // setup object cleaners
   muo_cleaner.reset(new MuonCleaner(AndId<Muon>(MuonIDTight(), PtEtaCut(45., 2.1))));
-  ele_cleaner.reset(new ElectronCleaner(AndId<Electron>(ElectronID_PHYS14_25ns_tight_noIso, PtEtaCut(50., 2.5))));
+  ele_cleaner.reset(new ElectronCleaner(AndId<Electron>(ElectronID_PHYS14_25ns_tight_noIso, PtEtaSCCut(50., 2.5))));
 
   jet_corrector.reset(new JetCorrector(JERFiles::PHYS14_L123_MC));
   jetlepton_cleaner.reset(new JetLeptonCleaner(JERFiles::PHYS14_L123_MC));
@@ -126,6 +126,7 @@ bool ZprimePreSelectionModule::process(Event & event) {
   jet_corrector->process(event);
   jetlepton_cleaner->process(event);
   jet_cleaner->process(event);
+
   topjet_corrector->process(event);
   topjetlepton_cleaner->process(event);
   topjet_cleaner->process(event);

--- a/src/ZprimeSelectionModule.cxx
+++ b/src/ZprimeSelectionModule.cxx
@@ -82,8 +82,9 @@ class ZprimeSelectionModule: public AnalysisModule {
   // ttbar reconstruction
   std::unique_ptr<AnalysisModule> ttgenprod;
   std::unique_ptr<AnalysisModule> reco_primlep;
-  std::unique_ptr<AnalysisModule> ttbar_reco_toptag0, ttbar_reco_toptag1;
-  std::unique_ptr<AnalysisModule> ttbar_chi2min;
+  std::unique_ptr<AnalysisModule> ttbar_reco__ttag0, ttbar_reco__ttag1;
+  std::unique_ptr<AnalysisModule> ttbar_chi2__ttag0, ttbar_chi2__ttag1;
+
   Event::Handle<std::vector<ReconstructionHypothesis>> h_ttbar_hyps;
 
   // hists
@@ -105,7 +106,7 @@ ZprimeSelectionModule::ZprimeSelectionModule(Context & ctx){
 
   //// OBJ CLEANING
   muo_cleaner.reset(new MuonCleaner(AndId<Muon>(MuonIDTight(), PtEtaCut(45., 2.1))));
-  ele_cleaner.reset(new ElectronCleaner(AndId<Electron>(ElectronID_PHYS14_25ns_tight_noIso, PtEtaCut(50., 2.5))));
+  ele_cleaner.reset(new ElectronCleaner(AndId<Electron>(ElectronID_PHYS14_25ns_tight_noIso, PtEtaSCCut(50., 2.5))));
   jet_corrector.reset(new JetCorrector(JERFiles::PHYS14_L123_MC));
   jetER_smearer.reset(new JetResolutionSmearer(ctx));
   jetlepton_cleaner.reset(new JetLeptonCleaner(JERFiles::PHYS14_L123_MC));
@@ -164,9 +165,12 @@ ZprimeSelectionModule::ZprimeSelectionModule(Context & ctx){
   reco_primlep.reset(new PrimaryLepton(ctx));
 
   std::string ttbar_hyps_label("TTbarReconstruction");
-  ttbar_reco_toptag0.reset(new HighMassTTbarReconstruction(ctx, NeutrinoReconstruction, ttbar_hyps_label));
-  ttbar_reco_toptag1.reset(new TopTagReconstruction(ctx, NeutrinoReconstruction, ttbar_hyps_label, topjetID, minDR_topjet_jet));
-  ttbar_chi2min.reset(new Chi2Discriminator(ctx, ttbar_hyps_label));
+  ttbar_reco__ttag0.reset(new HighMassTTbarReconstruction(ctx, NeutrinoReconstruction, ttbar_hyps_label));
+  ttbar_reco__ttag1.reset(new        TopTagReconstruction(ctx, NeutrinoReconstruction, ttbar_hyps_label, topjetID, minDR_topjet_jet));
+
+  ttbar_chi2__ttag0.reset(new Chi2Discriminator    (ctx, ttbar_hyps_label));
+  ttbar_chi2__ttag1.reset(new Chi2DiscriminatorTTAG(ctx, ttbar_hyps_label));
+
   h_ttbar_hyps = ctx.get_handle<std::vector<ReconstructionHypothesis>>(ttbar_hyps_label);
   ////
 
@@ -273,13 +277,13 @@ bool ZprimeSelectionModule::process(Event & event){
   reco_primlep->process(event);
 
   if(pass_toptagevent){
-    ttbar_reco_toptag1->process(event);
-    ttbar_chi2min->process(event);
+    ttbar_reco__ttag1->process(event);
+    ttbar_chi2__ttag1->process(event);
     chi2min_toptag1_h->fill(event);
   }
   else{
-    ttbar_reco_toptag0->process(event);
-    ttbar_chi2min->process(event);
+    ttbar_reco__ttag0->process(event);
+    ttbar_chi2__ttag0->process(event);
     chi2min_toptag0_h->fill(event);
   }
   ////


### PR DESCRIPTION
* updated chi2 calculation for 'top-tagged' events (using groomed jet mass for the chi2 hadronic term, as the ungroomed jet mass strongly depends on the resonance's mass and deviates from the GEN-level top mass; see slide 13 in https://indico.cern.ch/event/374668/contribution/0/material/slides/0.pdf)

* added some samples in config/ files
