### PR TITLE
AK4 b-tagging with CHS matched to PUPPI

### DIFF
--- a/include/ZprimeSemiLeptonicCHSMatchHists.h
+++ b/include/ZprimeSemiLeptonicCHSMatchHists.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "UHH2/core/include/Hists.h"
+#include "UHH2/core/include/Event.h"
+#include "UHH2/ZprimeSemiLeptonic/include/ZprimeSemiLeptonicModules.h"
+
+#include <UHH2/common/include/TTbarGen.h>
+#include <UHH2/common/include/TTbarReconstruction.h>
+#include <UHH2/common/include/ReconstructionHypothesisDiscriminators.h>
+
+
+class ZprimeSemiLeptonicCHSMatchHists: public uhh2::Hists {
+public:
+  explicit ZprimeSemiLeptonicCHSMatchHists(uhh2::Context&, const std::string&);
+  virtual void fill(const uhh2::Event&) override;
+
+protected:
+  void init();
+  bool is_mc;
+
+TH1F *N_jets, *pt_jet, *pt_jet1, *pt_jet2, *pt_jet3, *eta_jet, *eta_jet1, *eta_jet2, *eta_jet3, *phi_jet, *phi_jet1, *phi_jet2, *phi_jet3, *m_jet, *m_jet1, *m_jet2, *m_jet3, *bscore_jet, *bscore_jet1, *bscore_jet2, *bscore_jet3, *N_bJets_loose, *N_bJets_med, *N_bJets_tight;
+
+TH1F *CHS_matched_N_jets, *CHS_matched_pt_jet, *CHS_matched_pt_jet1, *CHS_matched_pt_jet2, *CHS_matched_pt_jet3, *CHS_matched_eta_jet, *CHS_matched_eta_jet1, *CHS_matched_eta_jet2, *CHS_matched_eta_jet3, *CHS_matched_phi_jet, *CHS_matched_phi_jet1, *CHS_matched_phi_jet2, *CHS_matched_phi_jet3, *CHS_matched_m_jet, *CHS_matched_m_jet1, *CHS_matched_m_jet2, *CHS_matched_m_jet3, *CHS_matched_bscore_jet, *CHS_matched_bscore_jet1, *CHS_matched_bscore_jet2, *CHS_matched_bscore_jet3, *CHS_matched_N_bJets_loose, *CHS_matched_N_bJets_med, *CHS_matched_N_bJets_tight;
+
+uhh2::Event::Handle< std::vector<Jet> > h_CHSjets_matched;
+  virtual ~ZprimeSemiLeptonicCHSMatchHists();
+};

--- a/include/ZprimeSemiLeptonicModules.h
+++ b/include/ZprimeSemiLeptonicModules.h
@@ -6,6 +6,9 @@
 #include <UHH2/ZprimeSemiLeptonic/include/ZprimeCandidate.h>
 #include <UHH2/core/include/LorentzVector.h>
 #include <UHH2/common/include/TTbarGen.h>
+#include <UHH2/common/include/NSelections.h>
+#include "UHH2/common/include/BTagCalibrationStandalone.h"
+#include "UHH2/common/include/JetIds.h"
 
 #include <UHH2/HOTVR/include/HOTVRIds.h>
 
@@ -170,6 +173,7 @@ public:
 private:
   uhh2::Event::Handle<bool> h_is_zprime_reconstructed_chi2;
   uhh2::Event::Handle<ZprimeCandidate*> h_BestZprimeCandidateChi2;
+  uhh2::Event::Handle< std::vector<Jet> > h_CHSjets_matched;
   uhh2::Event::Handle< float > h_eventweight;
   uhh2::Event::Handle< float > h_Mu_pt, h_Mu_eta, h_Mu_phi, h_Mu_E;
   uhh2::Event::Handle< float > h_Ele_pt, h_Ele_eta, h_Ele_phi, h_Ele_E;
@@ -238,4 +242,57 @@ class TopPtReweighting : public uhh2::AnalysisModule {
   std::string ttgen_name_;
   std::string weight_name_;
 };
+
+
+class PuppiCHS_matching : public uhh2::AnalysisModule {
+
+public:
+  explicit PuppiCHS_matching(uhh2::Context&);
+  virtual bool process(uhh2::Event&) override;
+
+private:
+  uhh2::Event::Handle< std::vector<Jet> > h_CHSjets;
+  uhh2::Event::Handle< std::vector<Jet> > h_CHS_matched_;
+};
+
+
+class CustomMCBTagDiscriminantReweighting: public uhh2::AnalysisModule {
+ public:
+  explicit CustomMCBTagDiscriminantReweighting(uhh2::Context & ctx,
+					 BTag::algo algorithm,
+					 const std::string & jets_handle_name="jets",
+					 const std::string & sysType="central",
+					 const std::string & measType="iterativefit",
+					 const std::string & weights_name_postfix="",
+					 const std::string & xml_calib_name="BTagCalibration");
+
+  virtual bool process(uhh2::Event & event) override;
+
+ protected:
+  BTag::algo algorithm_;
+  std::unique_ptr<BTagCalibrationReader> reader;
+  uhh2::Event::Handle<std::vector<Jet>> h_jets_;
+  uhh2::Event::Handle< std::vector<Jet> > h_CHSjets_matched;
+  std::string sysType_;
+  uhh2::Event::Handle<float> h_weight_btagdisc_central;
+  uhh2::Event::Handle<float> h_weight_btagdisc_jesup;
+  uhh2::Event::Handle<float> h_weight_btagdisc_jesdown;
+  uhh2::Event::Handle<float> h_weight_btagdisc_lfup;
+  uhh2::Event::Handle<float> h_weight_btagdisc_lfdown;
+  uhh2::Event::Handle<float> h_weight_btagdisc_hfup;
+  uhh2::Event::Handle<float> h_weight_btagdisc_hfdown;
+  uhh2::Event::Handle<float> h_weight_btagdisc_hfstats1up;
+  uhh2::Event::Handle<float> h_weight_btagdisc_hfstats1down;
+  uhh2::Event::Handle<float> h_weight_btagdisc_hfstats2up;
+  uhh2::Event::Handle<float> h_weight_btagdisc_hfstats2down;
+  uhh2::Event::Handle<float> h_weight_btagdisc_lfstats1up;
+  uhh2::Event::Handle<float> h_weight_btagdisc_lfstats1down;
+  uhh2::Event::Handle<float> h_weight_btagdisc_lfstats2up;
+  uhh2::Event::Handle<float> h_weight_btagdisc_lfstats2down;
+  uhh2::Event::Handle<float> h_weight_btagdisc_cferr1up;
+  uhh2::Event::Handle<float> h_weight_btagdisc_cferr1down;
+  uhh2::Event::Handle<float> h_weight_btagdisc_cferr2up;
+  uhh2::Event::Handle<float> h_weight_btagdisc_cferr2down;
+};
+
 

--- a/include/ZprimeSemiLeptonicSelections.h
+++ b/include/ZprimeSemiLeptonicSelections.h
@@ -20,8 +20,6 @@
 
 namespace uhh2 {
 
-
-
   class BlindDataSelection : public Selection{
   public:
     explicit BlindDataSelection(uhh2::Context&, float mtt_max);
@@ -316,5 +314,16 @@ namespace uhh2 {
     uhh2::Event::Handle<bool> h_is_zprime_reconstructed_chi2;
     float theta_cut_;
   };
+  ////
+
+  class PuppiCHS_BTagging : public Selection{
+  public:
+    explicit PuppiCHS_BTagging(uhh2::Context&);
+    virtual bool passes(const Event&) override;
+
+  private:
+  uhh2::Event::Handle< std::vector<Jet> > h_CHSjets_matched;
+  std::unique_ptr<Selection> sel_1btag;
+};
 
 }

--- a/src/JobConfig.dtd
+++ b/src/JobConfig.dtd
@@ -1,0 +1,1 @@
+/nfs/dust/cms/user/deleokse/RunII_106_v2/SFrameBatch//JobConfig.dtd

--- a/src/ZprimePreselectionModule.cxx
+++ b/src/ZprimePreselectionModule.cxx
@@ -219,7 +219,7 @@ double muon_pt_high(55.);
   //cout<<"Common Modules... "<<event.event<<endl;
   fill_histograms(event, "CommonModules");
 
-  //// correct AK4 CHS jets 
+  // Correct AK4 CHS jets 
   CHSjetCorr->process(event);
 
   // CLEANER MUONS

--- a/src/ZprimeSemiLeptonicCHSMatchHists.cxx
+++ b/src/ZprimeSemiLeptonicCHSMatchHists.cxx
@@ -1,0 +1,210 @@
+#include "UHH2/ZprimeSemiLeptonic/include/ZprimeSemiLeptonicCHSMatchHists.h"
+#include "UHH2/ZprimeSemiLeptonic/include/ZprimeSemiLeptonicModules.h"
+#include "UHH2/core/include/Event.h"
+#include <UHH2/core/include/Utils.h>
+#include <UHH2/common/include/Utils.h>
+#include "UHH2/common/include/JetIds.h"
+#include <math.h>
+
+#include <UHH2/common/include/TTbarGen.h>
+#include <UHH2/common/include/TTbarReconstruction.h>
+#include <UHH2/common/include/ReconstructionHypothesisDiscriminators.h>
+
+#include "TH1F.h"
+#include "TH2D.h"
+#include <iostream>
+
+using namespace std;
+using namespace uhh2;
+
+ZprimeSemiLeptonicCHSMatchHists::ZprimeSemiLeptonicCHSMatchHists(uhh2::Context& ctx, const std::string& dirname):
+Hists(ctx, dirname) {
+
+  is_mc = ctx.get("dataset_type") == "MC";
+  h_CHSjets_matched = ctx.get_handle<std::vector<Jet>>("CHS_matched");
+  init();
+}
+
+void ZprimeSemiLeptonicCHSMatchHists::init(){
+
+  // jets
+  N_jets            = book<TH1F>("N_jets", "N_{jets}", 21, -0.5, 20.5);
+  pt_jet            = book<TH1F>("pt_jet", "p_{T}^{jets} [GeV]", 50, 0, 1500);
+  pt_jet1           = book<TH1F>("pt_jet1", "p_{T}^{jet 1} [GeV]", 50, 0, 1500);
+  pt_jet2           = book<TH1F>("pt_jet2", "p_{T}^{jet 2} [GeV]", 50, 0, 1500);
+  pt_jet3           = book<TH1F>("pt_jet3", "p_{T}^{jet 3} [GeV]", 50, 0, 1500);
+  eta_jet           = book<TH1F>("eta_jet", "#eta^{jets}", 50, -2.5, 2.5);
+  eta_jet1          = book<TH1F>("eta_jet1", "#eta^{jet 1}", 50, -2.5, 2.5);
+  eta_jet2          = book<TH1F>("eta_jet2", "#eta^{jet 2}", 50, -2.5, 2.5);
+  eta_jet3          = book<TH1F>("eta_jet3", "#eta^{jet 3}", 50, -2.5, 2.5);
+  phi_jet           = book<TH1F>("phi_jet", "#phi^{jets}", 35, -3.5, 3.5);
+  phi_jet1          = book<TH1F>("phi_jet1", "#phi^{jet 1}", 35, -3.5, 3.5);
+  phi_jet2          = book<TH1F>("phi_jet2", "#phi^{jet 2}", 35, -3.5, 3.5);
+  phi_jet3          = book<TH1F>("phi_jet3", "#phi^{jet 3}", 35, -3.5, 3.5);
+  m_jet             = book<TH1F>("m_jet", "m^{jets}", 50, 0, 500);
+  m_jet1            = book<TH1F>("m_jet1", "m^{jet 1}", 50, 0, 500);
+  m_jet2            = book<TH1F>("m_jet2", "m^{jet 2}", 50, 0, 500);
+  m_jet3            = book<TH1F>("m_jet3", "m^{jet 3}", 50, 0, 500);
+  bscore_jet        = book<TH1F>("bscore_jet",  "bscore^{jets}", 20, 0, 1);
+  bscore_jet1       = book<TH1F>("bscore_jet1", "bscore^{jet 1}", 20, 0, 1);
+  bscore_jet2       = book<TH1F>("bscore_jet2", "bscore^{jet 2}", 20, 0, 1);
+  bscore_jet3       = book<TH1F>("bscore_jet3", "bscore^{jet 3}", 20, 0, 1);
+  N_bJets_loose     = book<TH1F>("N_bJets_loose", "N_{jets}^{bscore loose}", 11, -0.5, 10.5);
+  N_bJets_med       = book<TH1F>("N_bJets_med",   "N_{jets}^{bscore medium}", 11, -0.5, 10.5);
+  N_bJets_tight     = book<TH1F>("N_bJets_tight", "N_{jets}^{bscore tight}", 11, -0.5, 10.5);
+
+  // CHS matched jets
+  CHS_matched_N_jets            = book<TH1F>("CHS_matched_N_jets", "CHS matched N_{jets}", 21, -0.5, 20.5);
+  CHS_matched_pt_jet            = book<TH1F>("CHS_matched_pt_jet", "CHS matched p_{T}^{jets} [GeV]", 50, 0, 1500);
+  CHS_matched_pt_jet1           = book<TH1F>("CHS_matched_pt_jet1", "CHS matched p_{T}^{jet 1} [GeV]", 50, 0, 1500);
+  CHS_matched_pt_jet2           = book<TH1F>("CHS_matched_pt_jet2", "CHS matched p_{T}^{jet 2} [GeV]", 50, 0, 1500);
+  CHS_matched_pt_jet3           = book<TH1F>("CHS_matched_pt_jet3", "CHS matched p_{T}^{jet 3} [GeV]", 50, 0, 1500);
+  CHS_matched_eta_jet           = book<TH1F>("CHS_matched_eta_jet", "CHS matched #eta^{jets}", 50, -2.5, 2.5);
+  CHS_matched_eta_jet1          = book<TH1F>("CHS_matched_eta_jet1", "CHS matched #eta^{jet 1}", 50, -2.5, 2.5);
+  CHS_matched_eta_jet2          = book<TH1F>("CHS_matched_eta_jet2", "CHS matched #eta^{jet 2}", 50, -2.5, 2.5);
+  CHS_matched_eta_jet3          = book<TH1F>("CHS_matched_eta_jet3", "CHS matched #eta^{jet 3}", 50, -2.5, 2.5);
+  CHS_matched_phi_jet           = book<TH1F>("CHS_matched_phi_jet", "CHS matched #phi^{jets}", 35, -3.5, 3.5);
+  CHS_matched_phi_jet1          = book<TH1F>("CHS_matched_phi_jet1", "CHS matched #phi^{jet 1}", 35, -3.5, 3.5);
+  CHS_matched_phi_jet2          = book<TH1F>("CHS_matched_phi_jet2", "CHS matched #phi^{jet 2}", 35, -3.5, 3.5);
+  CHS_matched_phi_jet3          = book<TH1F>("CHS_matched_phi_jet3", "CHS matched #phi^{jet 3}", 35, -3.5, 3.5);
+  CHS_matched_m_jet             = book<TH1F>("CHS_matched_m_jet", "CHS matched m^{jets}", 50, 0, 500);
+  CHS_matched_m_jet1            = book<TH1F>("CHS_matched_m_jet1", "CHS matched m^{jet 1}", 50, 0, 500);
+  CHS_matched_m_jet2            = book<TH1F>("CHS_matched_m_jet2", "CHS matched m^{jet 2}", 50, 0, 500);
+  CHS_matched_m_jet3            = book<TH1F>("CHS_matched_m_jet3", "CHS matched m^{jet 3}", 50, 0, 500);
+  CHS_matched_bscore_jet        = book<TH1F>("CHS_matched_bscore_jet",  "CHS matched bscore^{jets}", 20, 0, 1);
+  CHS_matched_bscore_jet1       = book<TH1F>("CHS_matched_bscore_jet1", "CHS matched bscore^{jet 1}", 20, 0, 1);
+  CHS_matched_bscore_jet2       = book<TH1F>("CHS_matched_bscore_jet2", "CHS matched bscore^{jet 2}", 20, 0, 1);
+  CHS_matched_bscore_jet3       = book<TH1F>("CHS_matched_bscore_jet3", "CHS matched bscore^{jet 3}", 20, 0, 1);
+  CHS_matched_N_bJets_loose     = book<TH1F>("CHS_matched_N_bJets_loose", "CHS matched N_{jets}^{bscore loose}", 11, -0.5, 10.5);
+  CHS_matched_N_bJets_med       = book<TH1F>("CHS_matched_N_bJets_med",   "CHS matched N_{jets}^{bscore medium}", 11, -0.5, 10.5);
+  CHS_matched_N_bJets_tight     = book<TH1F>("CHS_matched_N_bJets_tight", "CHS matched N_{jets}^{bscore tight}", 11, -0.5, 10.5);
+
+}
+
+
+void ZprimeSemiLeptonicCHSMatchHists::fill(const Event & event){
+
+  double weight = event.weight;
+
+  /*
+  █      ██ ███████ ████████ ███████
+  █      ██ ██         ██    ██
+  █      ██ █████      ██    ███████
+  █ ██   ██ ██         ██         ██
+  █  █████  ███████    ██    ███████
+  */
+
+  vector<Jet>* jets = event.jets;
+  int Njets = jets->size();
+  N_jets->Fill(Njets, weight);
+
+  for(unsigned int i=0; i<jets->size(); i++){
+    pt_jet->Fill(jets->at(i).pt(),weight);
+    eta_jet->Fill(jets->at(i).eta(),weight);
+    phi_jet->Fill(jets->at(i).phi(),weight);
+    m_jet->Fill(jets->at(i).v4().M(),weight);
+    bscore_jet->Fill(jets->at(i).btag_DeepJet(), weight);
+    if(i==0){
+      pt_jet1->Fill(jets->at(i).pt(),weight);
+      eta_jet1->Fill(jets->at(i).eta(),weight);
+      phi_jet1->Fill(jets->at(i).phi(),weight);
+      m_jet1->Fill(jets->at(i).v4().M(),weight);
+      bscore_jet1->Fill(jets->at(i).btag_DeepJet(), weight);
+    }
+    else if(i==1){
+      pt_jet2->Fill(jets->at(i).pt(),weight);
+      eta_jet2->Fill(jets->at(i).eta(),weight);
+      phi_jet2->Fill(jets->at(i).phi(),weight);
+      m_jet2->Fill(jets->at(i).v4().M(),weight);
+      bscore_jet2->Fill(jets->at(i).btag_DeepJet(), weight);
+    }
+    else if(i==2){
+      pt_jet3->Fill(jets->at(i).pt(),weight);
+      eta_jet3->Fill(jets->at(i).eta(),weight);
+      phi_jet3->Fill(jets->at(i).phi(),weight);
+      m_jet3->Fill(jets->at(i).v4().M(),weight);
+      bscore_jet3->Fill(jets->at(i).btag_DeepJet(), weight);
+    }
+  }
+
+  int Nbjets_loose = 0, Nbjets_medium = 0, Nbjets_tight = 0;
+  DeepJetBTag Btag_loose  = DeepJetBTag(DeepJetBTag::WP_LOOSE);
+  DeepJetBTag Btag_medium = DeepJetBTag(DeepJetBTag::WP_MEDIUM);
+  DeepJetBTag Btag_tight  = DeepJetBTag(DeepJetBTag::WP_TIGHT);
+
+  for (unsigned int i =0; i<jets->size(); i++) {
+    if(Btag_loose(jets->at(i),event))  Nbjets_loose++;
+    if(Btag_medium(jets->at(i),event)) Nbjets_medium++;
+    if(Btag_tight(jets->at(i),event))  Nbjets_tight++;
+  }
+
+  N_bJets_loose->Fill(Nbjets_loose,weight);
+  N_bJets_med->Fill(Nbjets_medium,weight);
+  N_bJets_tight->Fill(Nbjets_tight,weight);
+
+
+  /*
+  █  ██████ ██   ██ ███████      ██ ███████ ████████ ███████
+  █ ██      ██   ██ ██           ██ ██         ██    ██
+  █ ██      ███████ ███████      ██ █████      ██    ███████
+  █ ██      ██   ██      ██ ██   ██ ██         ██         ██
+  █  ██████ ██   ██ ███████  █████  ███████    ██    ███████
+  */
+
+  //// Matched to Puppi jets
+
+  vector<Jet> AK4CHSjets_matched = event.get(h_CHSjets_matched);
+  int CHS_matched_Njets = AK4CHSjets_matched.size();
+  CHS_matched_N_jets->Fill(CHS_matched_Njets, weight);
+
+  for(unsigned int i=0; i<AK4CHSjets_matched.size(); i++){
+    CHS_matched_pt_jet->Fill(AK4CHSjets_matched.at(i).pt(),weight);
+    CHS_matched_eta_jet->Fill(AK4CHSjets_matched.at(i).eta(),weight);
+    CHS_matched_phi_jet->Fill(AK4CHSjets_matched.at(i).phi(),weight);
+    CHS_matched_m_jet->Fill(AK4CHSjets_matched.at(i).v4().M(),weight);
+    CHS_matched_bscore_jet->Fill(AK4CHSjets_matched.at(i).btag_DeepJet(), weight);
+    if(i==0){
+      CHS_matched_pt_jet1->Fill(AK4CHSjets_matched.at(i).pt(),weight);
+      CHS_matched_eta_jet1->Fill(AK4CHSjets_matched.at(i).eta(),weight);
+      CHS_matched_phi_jet1->Fill(AK4CHSjets_matched.at(i).phi(),weight);
+      CHS_matched_m_jet1->Fill(AK4CHSjets_matched.at(i).v4().M(),weight);
+      CHS_matched_bscore_jet1->Fill(AK4CHSjets_matched.at(i).btag_DeepJet(), weight);
+    }
+    else if(i==1){
+      CHS_matched_pt_jet2->Fill(AK4CHSjets_matched.at(i).pt(),weight);
+      CHS_matched_eta_jet2->Fill(AK4CHSjets_matched.at(i).eta(),weight);
+      CHS_matched_phi_jet2->Fill(AK4CHSjets_matched.at(i).phi(),weight);
+      CHS_matched_m_jet2->Fill(AK4CHSjets_matched.at(i).v4().M(),weight);
+      CHS_matched_bscore_jet2->Fill(AK4CHSjets_matched.at(i).btag_DeepJet(), weight);
+    }
+    else if(i==2){
+      CHS_matched_pt_jet3->Fill(AK4CHSjets_matched.at(i).pt(),weight);
+      CHS_matched_eta_jet3->Fill(AK4CHSjets_matched.at(i).eta(),weight);
+      CHS_matched_phi_jet3->Fill(AK4CHSjets_matched.at(i).phi(),weight);
+      CHS_matched_m_jet3->Fill(AK4CHSjets_matched.at(i).v4().M(),weight);
+      CHS_matched_bscore_jet3->Fill(AK4CHSjets_matched.at(i).btag_DeepJet(), weight);
+    }
+  }
+
+  int CHS_matched_Nbjets_loose = 0, CHS_matched_Nbjets_medium = 0, CHS_matched_Nbjets_tight = 0;
+  DeepJetBTag CHS_matched_Btag_loose  = DeepJetBTag(DeepJetBTag::WP_LOOSE);
+  DeepJetBTag CHS_matched_Btag_medium = DeepJetBTag(DeepJetBTag::WP_MEDIUM);
+  DeepJetBTag CHS_matched_Btag_tight  = DeepJetBTag(DeepJetBTag::WP_TIGHT);
+
+  for (unsigned int i =0; i<AK4CHSjets_matched.size(); i++) {
+    if(CHS_matched_Btag_loose(AK4CHSjets_matched.at(i),event))  CHS_matched_Nbjets_loose++;
+    if(CHS_matched_Btag_medium(AK4CHSjets_matched.at(i),event)) CHS_matched_Nbjets_medium++;
+    if(CHS_matched_Btag_tight(AK4CHSjets_matched.at(i),event))  CHS_matched_Nbjets_tight++;
+  }
+
+  CHS_matched_N_bJets_loose->Fill(CHS_matched_Nbjets_loose,weight);
+  CHS_matched_N_bJets_med->Fill(CHS_matched_Nbjets_medium,weight);
+  CHS_matched_N_bJets_tight->Fill(CHS_matched_Nbjets_tight,weight);
+
+
+
+} //Method
+
+
+
+ZprimeSemiLeptonicCHSMatchHists::~ZprimeSemiLeptonicCHSMatchHists(){}

--- a/src/ZprimeSemiLeptonicHists.cxx
+++ b/src/ZprimeSemiLeptonicHists.cxx
@@ -543,7 +543,6 @@ void ZprimeSemiLeptonicHists::fill(const Event & event){
   N_bJetsDeepJet_med->Fill(NbjetsDeepJet_medium,weight);
   N_bJetsDeepJet_tight->Fill(NbjetsDeepJet_tight,weight);
 
-
   /*
   █ ██   ██    █████  ██████ ██    ██   █████
   █ ██   ██  ██     ██  ██   ██    ██   ██  ██
@@ -718,7 +717,6 @@ void ZprimeSemiLeptonicHists::fill(const Event & event){
       tau32_HOTVRTaggedjet3->Fill(tau32, weight);
     }
 
-
   }
 
   N_HOTVRjets->Fill(NHOTVRjets, weight);
@@ -863,7 +861,6 @@ void ZprimeSemiLeptonicHists::fill(const Event & event){
   vector<Muon>* muons = event.muons;
   int Nmuons = muons->size();
   N_mu->Fill(Nmuons, weight);
-
   for(int i=0; i<Nmuons; i++){
 
     pt_mu->Fill(muons->at(i).pt(),weight);
@@ -973,7 +970,6 @@ void ZprimeSemiLeptonicHists::fill(const Event & event){
       M_ee->Fill((electrons->at(i).v4() + electrons->at(j).v4()).M() ,weight);
     }
   }
-
 
   /*
   ██████  ███████ ███    ██ ███████ ██████   █████  ██
@@ -1240,7 +1236,6 @@ void ZprimeSemiLeptonicHists::fill(const Event & event){
       NN_Ak4_j6_btag->Fill(Ak4jets->at(i).btag_DeepJet(),weight);
     }
   }
-
 
   int N_HOTVRjets = HOTVRjets->size();
   NN_N_HOTVR->Fill(N_HOTVRjets,weight);

--- a/src/ZprimeSemiLeptonicModules.cxx
+++ b/src/ZprimeSemiLeptonicModules.cxx
@@ -5,6 +5,10 @@
 #include <UHH2/core/include/Utils.h>
 #include <UHH2/common/include/Utils.h>
 #include <UHH2/ZprimeSemiLeptonic/include/ZprimeCandidate.h>
+#include "UHH2/core/include/Event.h"
+#include <UHH2/common/include/NSelections.h>
+#include "UHH2/common/include/BTagCalibrationStandalone.h"
+#include "UHH2/common/include/MCWeight.h"
 
 #include "boost/algorithm/string.hpp"
 
@@ -941,7 +945,7 @@ bool MEPartonFinder::process(uhh2::Event& evt){
 Variables_NN::Variables_NN(uhh2::Context& ctx){
   h_BestZprimeCandidateChi2 = ctx.get_handle<ZprimeCandidate*>("ZprimeCandidateBestChi2");
   h_is_zprime_reconstructed_chi2 = ctx.get_handle<bool>("is_zprime_reconstructed_chi2");
-
+  h_CHSjets_matched = ctx.get_handle<std::vector<Jet>>("CHS_matched");
   h_eventweight = ctx.declare_event_output<float> ("eventweight");
 
 ///  MUONS
@@ -1142,7 +1146,7 @@ bool Variables_NN::process(uhh2::Event& evt){
       evt.set(h_Ak4_j1_phi, Ak4jets->at(i).phi());
       evt.set(h_Ak4_j1_E, Ak4jets->at(i).energy());
       evt.set(h_Ak4_j1_m, Ak4jets->at(i).v4().M());
-      evt.set(h_Ak4_j1_deepjetbscore, Ak4jets->at(i).btag_DeepJet());
+      //evt.set(h_Ak4_j1_deepjetbscore, Ak4jets->at(i).btag_DeepJet());
       }
       if(i==1){
       evt.set(h_Ak4_j2_pt, Ak4jets->at(i).pt());
@@ -1150,7 +1154,7 @@ bool Variables_NN::process(uhh2::Event& evt){
       evt.set(h_Ak4_j2_phi, Ak4jets->at(i).phi());
       evt.set(h_Ak4_j2_E, Ak4jets->at(i).energy());
       evt.set(h_Ak4_j2_m, Ak4jets->at(i).v4().M());
-      evt.set(h_Ak4_j2_deepjetbscore, Ak4jets->at(i).btag_DeepJet());
+      //evt.set(h_Ak4_j2_deepjetbscore, Ak4jets->at(i).btag_DeepJet());
       }
       if(i==2){
       evt.set(h_Ak4_j3_pt, Ak4jets->at(i).pt());
@@ -1158,7 +1162,7 @@ bool Variables_NN::process(uhh2::Event& evt){
       evt.set(h_Ak4_j3_phi, Ak4jets->at(i).phi());
       evt.set(h_Ak4_j3_E, Ak4jets->at(i).energy());
       evt.set(h_Ak4_j3_m, Ak4jets->at(i).v4().M());
-      evt.set(h_Ak4_j3_deepjetbscore, Ak4jets->at(i).btag_DeepJet());
+      //evt.set(h_Ak4_j3_deepjetbscore, Ak4jets->at(i).btag_DeepJet());
       }
       if(i==3){
       evt.set(h_Ak4_j4_pt, Ak4jets->at(i).pt());
@@ -1166,7 +1170,7 @@ bool Variables_NN::process(uhh2::Event& evt){
       evt.set(h_Ak4_j4_phi, Ak4jets->at(i).phi());
       evt.set(h_Ak4_j4_E, Ak4jets->at(i).energy());
       evt.set(h_Ak4_j4_m, Ak4jets->at(i).v4().M());
-      evt.set(h_Ak4_j4_deepjetbscore, Ak4jets->at(i).btag_DeepJet());
+      //evt.set(h_Ak4_j4_deepjetbscore, Ak4jets->at(i).btag_DeepJet());
       }
       if(i==4){
       evt.set(h_Ak4_j5_pt, Ak4jets->at(i).pt());
@@ -1174,7 +1178,7 @@ bool Variables_NN::process(uhh2::Event& evt){
       evt.set(h_Ak4_j5_phi, Ak4jets->at(i).phi());
       evt.set(h_Ak4_j5_E, Ak4jets->at(i).energy());
       evt.set(h_Ak4_j5_m, Ak4jets->at(i).v4().M());
-      evt.set(h_Ak4_j5_deepjetbscore, Ak4jets->at(i).btag_DeepJet());
+      //evt.set(h_Ak4_j5_deepjetbscore, Ak4jets->at(i).btag_DeepJet());
       }
       if(i==5){
       evt.set(h_Ak4_j6_pt, Ak4jets->at(i).pt());
@@ -1182,10 +1186,32 @@ bool Variables_NN::process(uhh2::Event& evt){
       evt.set(h_Ak4_j6_phi, Ak4jets->at(i).phi());
       evt.set(h_Ak4_j6_E, Ak4jets->at(i).energy());
       evt.set(h_Ak4_j6_m, Ak4jets->at(i).v4().M());
-      evt.set(h_Ak4_j6_deepjetbscore, Ak4jets->at(i).btag_DeepJet());
+      //evt.set(h_Ak4_j6_deepjetbscore, Ak4jets->at(i).btag_DeepJet());
       }
   }
 
+  // save b-tag score of matched CHS jet
+  vector<Jet> AK4CHSjets_matched = evt.get(h_CHSjets_matched);
+  for(int i=0; i<AK4CHSjets_matched.size(); i++){
+      if(i==0){
+      evt.set(h_Ak4_j1_deepjetbscore, AK4CHSjets_matched.at(i).btag_DeepJet());
+      }
+      if(i==1){
+      evt.set(h_Ak4_j2_deepjetbscore, AK4CHSjets_matched.at(i).btag_DeepJet());
+      }
+      if(i==2){
+      evt.set(h_Ak4_j3_deepjetbscore, AK4CHSjets_matched.at(i).btag_DeepJet());
+      }
+      if(i==3){
+      evt.set(h_Ak4_j4_deepjetbscore, AK4CHSjets_matched.at(i).btag_DeepJet());
+      }
+      if(i==4){
+      evt.set(h_Ak4_j5_deepjetbscore, AK4CHSjets_matched.at(i).btag_DeepJet());
+      }
+      if(i==5){
+      evt.set(h_Ak4_j6_deepjetbscore, AK4CHSjets_matched.at(i).btag_DeepJet());
+      }
+  }
 
 
 /////////   HOTVR JETS
@@ -1426,3 +1452,252 @@ bool TopPtReweighting::process(uhh2::Event& event){
 
 
 ////
+
+PuppiCHS_matching::PuppiCHS_matching(uhh2::Context& ctx){
+
+  h_CHSjets = ctx.get_handle< std::vector<Jet> >("jetsAk4CHS");
+  h_CHS_matched_    = ctx.declare_event_output<vector<Jet>>("CHS_matched");
+
+}
+
+bool PuppiCHS_matching::process(uhh2::Event& event){
+
+  vector<Jet> CHSjets = event.get(h_CHSjets);
+  std::vector<Jet> matched_jets;
+  std::vector<Jet> matched_jets_PUPPI;
+
+  for(const Jet & jet : *event.jets){
+     double deltaR_min = 99;
+
+     for(const Jet & CHSjet : CHSjets){
+        double deltaR_CHS = deltaR(jet,CHSjet);
+        if(deltaR_CHS<deltaR_min) deltaR_min = deltaR_CHS;
+     } //CHS loop 
+
+     if(deltaR_min>0.2) continue;
+
+     for(const Jet & CHSjet : CHSjets){
+     if(deltaR(jet,CHSjet)!=deltaR_min) continue;
+     else{
+      matched_jets.emplace_back(CHSjet);
+      matched_jets_PUPPI.emplace_back(jet);
+     }
+     }
+
+  } // PUPPI loop
+  std::swap(matched_jets_PUPPI, *event.jets);
+  event.set(h_CHS_matched_, matched_jets);
+  if(event.jets->size()==0) return false;
+  return true;
+}
+
+CustomMCBTagDiscriminantReweighting::CustomMCBTagDiscriminantReweighting(uhh2::Context & ctx,
+            BTag::algo algorithm,
+            const std::string & jets_handle_name,
+            const std::string & sysType,
+            const std::string & measType,
+            const std::string & weights_name_postfix,
+            const std::string & xml_calib_name):
+            algorithm_(algorithm),
+            h_jets_(ctx.get_handle<std::vector<Jet>>(jets_handle_name)),
+            h_CHSjets_matched(ctx.get_handle< std::vector<Jet> >("CHS_matched")),
+            sysType_(sysType),
+            h_weight_btagdisc_central (ctx.declare_event_output<float>("weight_btagdisc_central"+weights_name_postfix)),
+            h_weight_btagdisc_jesup (ctx.declare_event_output<float>("weight_btagdisc_jesup"+weights_name_postfix)),
+            h_weight_btagdisc_jesdown (ctx.declare_event_output<float>("weight_btagdisc_jesdown"+weights_name_postfix)),
+            h_weight_btagdisc_lfup (ctx.declare_event_output<float>("weight_btagdisc_lfup"+weights_name_postfix)),
+            h_weight_btagdisc_lfdown (ctx.declare_event_output<float>("weight_btagdisc_lfdown"+weights_name_postfix)),
+            h_weight_btagdisc_hfup (ctx.declare_event_output<float>("weight_btagdisc_hfup"+weights_name_postfix)),
+            h_weight_btagdisc_hfdown (ctx.declare_event_output<float>("weight_btagdisc_hfdown"+weights_name_postfix)),
+            h_weight_btagdisc_hfstats1up (ctx.declare_event_output<float>("weight_btagdisc_hfstats1up"+weights_name_postfix)),
+            h_weight_btagdisc_hfstats1down (ctx.declare_event_output<float>("weight_btagdisc_hfstats1down"+weights_name_postfix)),
+            h_weight_btagdisc_hfstats2up (ctx.declare_event_output<float>("weight_btagdisc_hfstats2up"+weights_name_postfix)),
+            h_weight_btagdisc_hfstats2down (ctx.declare_event_output<float>("weight_btagdisc_hfstats2down"+weights_name_postfix)),
+            h_weight_btagdisc_lfstats1up (ctx.declare_event_output<float>("weight_btagdisc_lfstats1up"+weights_name_postfix)),
+            h_weight_btagdisc_lfstats1down (ctx.declare_event_output<float>("weight_btagdisc_lfstats1down"+weights_name_postfix)),
+            h_weight_btagdisc_lfstats2up (ctx.declare_event_output<float>("weight_btagdisc_lfstats2up"+weights_name_postfix)),
+            h_weight_btagdisc_lfstats2down (ctx.declare_event_output<float>("weight_btagdisc_lfstats2down"+weights_name_postfix)),
+            h_weight_btagdisc_cferr1up (ctx.declare_event_output<float>("weight_btagdisc_cferr1up"+weights_name_postfix)),
+            h_weight_btagdisc_cferr1down (ctx.declare_event_output<float>("weight_btagdisc_cferr1down"+weights_name_postfix)),
+            h_weight_btagdisc_cferr2up (ctx.declare_event_output<float>("weight_btagdisc_cferr2up"+weights_name_postfix)),
+            h_weight_btagdisc_cferr2down (ctx.declare_event_output<float>("weight_btagdisc_cferr2down"+weights_name_postfix))
+            {
+              auto dataset_type = ctx.get("dataset_type");
+              bool is_mc = dataset_type == "MC";
+              if (!is_mc) {
+                cout << "Warning: CustomMCBTagDiscriminantReweighting will not have an effect on "
+                <<" this non-MC sample (dataset_type = '" + dataset_type + "')" << endl;
+                return;
+              }
+
+              BTagCalibration calibration("tagger", ctx.get(xml_calib_name)); // CHECK: the first std::string argument here should not be relevant
+              reader.reset(new BTagCalibrationReader(BTagEntry::OP_RESHAPING,"central",
+              {"up_jes","down_jes",
+              "up_lf","down_lf",
+              "up_hf","down_hf",
+              "up_hfstats1","down_hfstats1",
+              "up_hfstats2","down_hfstats2",
+              "up_lfstats1","down_lfstats1",
+              "up_lfstats2","down_lfstats2",
+              "up_cferr1","down_cferr1",
+              "up_cferr2","down_cferr2"}));
+              reader->load(calibration,BTagEntry::FLAV_B,measType);
+              reader->load(calibration,BTagEntry::FLAV_C,measType);
+              reader->load(calibration,BTagEntry::FLAV_UDSG,measType);
+
+            }
+            bool CustomMCBTagDiscriminantReweighting::process(Event & event) {
+
+
+              if (event.isRealData) {
+                event.set(h_weight_btagdisc_central,1.);
+                event.set(h_weight_btagdisc_jesup,1.);
+                event.set(h_weight_btagdisc_jesdown,1.);
+                event.set(h_weight_btagdisc_lfup,1.);
+                event.set(h_weight_btagdisc_lfdown,1.);
+                event.set(h_weight_btagdisc_hfup,1.);
+                event.set(h_weight_btagdisc_hfdown,1.);
+                event.set(h_weight_btagdisc_hfstats1up,1.);
+                event.set(h_weight_btagdisc_hfstats1down,1.);
+                event.set(h_weight_btagdisc_hfstats2up,1.);
+                event.set(h_weight_btagdisc_hfstats2down,1.);
+                event.set(h_weight_btagdisc_lfstats1up,1.);
+                event.set(h_weight_btagdisc_lfstats1down,1.);
+                event.set(h_weight_btagdisc_lfstats2up,1.);
+                event.set(h_weight_btagdisc_lfstats2down,1.);
+                event.set(h_weight_btagdisc_cferr1up,1.);
+                event.set(h_weight_btagdisc_cferr1down,1.);
+                event.set(h_weight_btagdisc_cferr2up,1.);
+                event.set(h_weight_btagdisc_cferr2down,1.);
+                return true;
+              }
+
+              float weight_central = 1.0;
+              float weight_jesup = 1.0;
+              float weight_jesdown = 1.0;
+              float weight_lfup = 1.0;
+              float weight_lfdown = 1.0;
+              float weight_hfup = 1.0;
+              float weight_hfdown = 1.0;
+              float weight_hfstats1up = 1.0;
+              float weight_hfstats1down = 1.0;
+              float weight_hfstats2up = 1.0;
+              float weight_hfstats2down = 1.0;
+              float weight_lfstats1up = 1.0;
+              float weight_lfstats1down = 1.0;
+              float weight_lfstats2up = 1.0;
+              float weight_lfstats2down = 1.0;
+              float weight_cferr1up = 1.0;
+              float weight_cferr1down = 1.0;
+              float weight_cferr2up = 1.0;
+              float weight_cferr2down = 1.0;
+
+              const auto &  CHSjets = event.get(h_CHSjets_matched);
+              const auto & jets = event.get(h_jets_);
+              for (size_t ijet=0; ijet < jets.size(); ijet++) {
+                Jet jet = jets.at(ijet);
+                float PUPPIjet_pt = jet.pt();
+                float PUPPIjet_eta = jet.eta();
+
+                 double deltaR_min = 99;
+                 for(size_t iCHSjet=0; iCHSjet < CHSjets.size(); iCHSjet++){
+                    Jet CHSjet = CHSjets.at(iCHSjet);
+                    double deltaR_CHS = deltaR(jet,CHSjet);
+                    if(deltaR_CHS<deltaR_min) deltaR_min = deltaR_CHS;
+                 }
+                 if(deltaR_min>0.2) continue;
+                 for(size_t iCHSjet=0; iCHSjet < CHSjets.size(); iCHSjet++){
+                    Jet CHSjet = CHSjets.at(iCHSjet);
+                    double deltaR_CHS = deltaR(jet,CHSjet);
+                 if(deltaR_CHS!=deltaR_min) continue;
+                 float jet_pt = CHSjet.pt();
+                 float jet_eta = CHSjet.eta();
+
+                float jet_btagdisc;
+                if (algorithm_ == BTag::DEEPCSV) jet_btagdisc = CHSjet.btag_DeepCSV();
+                else if (algorithm_ == BTag::DEEPJET) jet_btagdisc = CHSjet.btag_DeepJet();
+                else throw runtime_error("CustomMCBTagDiscriminantReweighting::process: Given b-tagging algorithm is (right now) not suited to be used jointly with this routine. Please check if it is compatible and then add your chosen algorithm as option to this analysis module. Adjust the routine if necessary.");
+
+                if (jet_btagdisc < 0.0) jet_btagdisc = -0.05;
+                if (jet_btagdisc > 1.0) jet_btagdisc = 1.0;
+
+                BTagEntry::JetFlavor jet_flavor = BTagEntry::FLAV_UDSG;
+                if (abs(CHSjet.hadronFlavour()) == 5) jet_flavor = BTagEntry::FLAV_B;
+                else if (abs(CHSjet.hadronFlavour()) == 4) jet_flavor = BTagEntry::FLAV_C;
+
+                if( jet_pt > 20.0 && fabs(jet_eta) < 2.4) {
+                  weight_central *= reader->eval_auto_bounds("central",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                  if (jet_flavor == BTagEntry::FLAV_B) {
+                    weight_jesup *= reader->eval_auto_bounds("up_jes",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                    weight_jesdown *= reader->eval_auto_bounds("down_jes",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                    weight_lfup *= reader->eval_auto_bounds("up_lf",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                    weight_lfdown *= reader->eval_auto_bounds("down_lf",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                    weight_hfstats1up *= reader->eval_auto_bounds("up_hfstats1",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                    weight_hfstats1down *= reader->eval_auto_bounds("down_hfstats1",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                    weight_hfstats2up *= reader->eval_auto_bounds("up_hfstats2",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                    weight_hfstats2down *= reader->eval_auto_bounds("down_hfstats2",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                  }
+                  if (jet_flavor == BTagEntry::FLAV_C) {
+                    weight_cferr1up *= reader->eval_auto_bounds("up_cferr1",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                    weight_cferr1down *= reader->eval_auto_bounds("down_cferr1",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                    weight_cferr2up *= reader->eval_auto_bounds("up_cferr2",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                    weight_cferr2down *= reader->eval_auto_bounds("down_cferr2",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                  }
+                  if (jet_flavor == BTagEntry::FLAV_UDSG) {
+                    weight_jesup *= reader->eval_auto_bounds("up_jes",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                    weight_jesdown *= reader->eval_auto_bounds("down_jes",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                    weight_hfup *= reader->eval_auto_bounds("up_hf",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                    weight_hfdown *= reader->eval_auto_bounds("down_hf",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                    weight_lfstats1up *= reader->eval_auto_bounds("up_lfstats1",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                    weight_lfstats1down *= reader->eval_auto_bounds("down_lfstats1",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                    weight_lfstats2up *= reader->eval_auto_bounds("up_lfstats2",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                    weight_lfstats2down *= reader->eval_auto_bounds("down_lfstats2",jet_flavor, jet_eta, jet_pt, jet_btagdisc);
+                  }
+                }
+              } // Loop CHS
+              } // Loop PUPPI
+
+              event.set(h_weight_btagdisc_central, weight_central);
+              event.set(h_weight_btagdisc_jesup, weight_jesup);
+              event.set(h_weight_btagdisc_jesdown, weight_jesdown);
+              event.set(h_weight_btagdisc_lfup, weight_lfup);
+              event.set(h_weight_btagdisc_lfdown, weight_lfdown);
+              event.set(h_weight_btagdisc_hfup, weight_hfup);
+              event.set(h_weight_btagdisc_hfdown, weight_hfdown);
+              event.set(h_weight_btagdisc_hfstats1up, weight_hfstats1up);
+              event.set(h_weight_btagdisc_hfstats1down, weight_hfstats1down);
+              event.set(h_weight_btagdisc_hfstats2up, weight_hfstats2up);
+              event.set(h_weight_btagdisc_hfstats2down, weight_hfstats2down);
+              event.set(h_weight_btagdisc_lfstats1up, weight_lfstats1up);
+              event.set(h_weight_btagdisc_lfstats1down, weight_lfstats1down);
+              event.set(h_weight_btagdisc_lfstats2up, weight_lfstats2up);
+              event.set(h_weight_btagdisc_lfstats2down, weight_lfstats2down);
+              event.set(h_weight_btagdisc_cferr1up, weight_cferr1up);
+              event.set(h_weight_btagdisc_cferr1down, weight_cferr1down);
+              event.set(h_weight_btagdisc_cferr2up, weight_cferr2up);
+              event.set(h_weight_btagdisc_cferr2down, weight_cferr2down);
+
+              if (sysType_ == "jesup") {event.weight *= weight_jesup;}
+              else if (sysType_ == "jesdown") {event.weight *= weight_jesdown;}
+              else if (sysType_ == "lfup") {event.weight *= weight_lfup;}
+              else if (sysType_ == "lfdown") {event.weight *= weight_lfdown;}
+              else if (sysType_ == "hfup") {event.weight *= weight_hfup;}
+              else if (sysType_ == "hfdown") {event.weight *= weight_hfdown;}
+              else if (sysType_ == "hfstats1up") {event.weight *= weight_hfstats1up;}
+              else if (sysType_ == "hfstats1down") {event.weight *= weight_hfstats1down;}
+              else if (sysType_ == "hfstats2up") {event.weight *= weight_hfstats2up;}
+              else if (sysType_ == "hfstats2down") {event.weight *= weight_hfstats2down;}
+              else if (sysType_ == "lfstats1up") {event.weight *= weight_lfstats1up;}
+              else if (sysType_ == "lfstats1down") {event.weight *= weight_lfstats1down;}
+              else if (sysType_ == "lfstats2up") {event.weight *= weight_lfstats2up;}
+              else if (sysType_ == "lfstats2down") {event.weight *= weight_lfstats2down;}
+              else if (sysType_ == "cferr1up") {event.weight *= weight_cferr1up;}
+              else if (sysType_ == "cferr1down") {event.weight *= weight_cferr1down;}
+              else if (sysType_ == "cferr2up") {event.weight *= weight_cferr2up;}
+              else if (sysType_ == "cferr2down") {event.weight *= weight_cferr2down;}
+              else {event.weight *= weight_central;}
+
+              return true;
+            }
+////
+


### PR DESCRIPTION
Match AK4 CHS to PUPPI and apply b-tagging on matched CHS jets. This is done because BTV does not support PUPPI for b-tagging