### PR TITLE
[106X] update lepton scale factors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ obj/*
 .fuse_*
 *.bak
 config/workdir_*
+config/jobTempOutput_*
 plotting/*

--- a/config/NonResAnalysis_106X_UL18_electron.xml
+++ b/config/NonResAnalysis_106X_UL18_electron.xml
@@ -11,6 +11,7 @@
 <!ENTITY IS_LOOSER_SELECTION "false">
 <!ENTITY CHANNEL             "electron">
 <!ENTITY OUTPUTdir           "/nfs/dust/cms/group/zprime-uhh/Analysis_UL18/&CHANNEL;/">
+<!-- <!ENTITY OUTPUTdir           "/nfs/dust/cms/user/jabuschh/ZprimeSemiLeptonic/RunII_106X_v2/UL18/&CHANNEL;/"> -->
 
 <!-- DATA -->
 <!ENTITY DATA_EGamma_RunA_UL18     SYSTEM  "../data/Skimming_datasets_UL18_preselection/DATA_EGamma_RunA_UL18.xml">
@@ -335,7 +336,7 @@
 
 			<Item Name="MCBtagEfficiencies" Value = "/nfs/dust/cms/user/jabuschh/uhh2-106X_v2/CMSSW_10_6_28/src/UHH2/ZprimeSemiLeptonic/data/2018/BTagMCEfficiencyHists_muon2018.root"/>
 			<Item Name="BTagCalibration"    Value = "/nfs/dust/cms/user/jabuschh/uhh2-106X_v2/CMSSW_10_6_28/src/UHH2/common/UHH2-data/UL18/reshaping_deepJet_106XUL18_v2.csv"/> <!-- reshape -->
-			<Item Name="HOTVRTopTagSFs"     Value = "/nfs/dust/cms/user/jabuschh/uhh2-106X_v2/CMSSW_10_6_28/src/UHH2/HOTVR/data/TopTaggingScaleFactors_RunIISummer19UL18_PUPPIv15.root"/>
+			<!-- <Item Name="HOTVRTopTagSFs"     Value = "/nfs/dust/cms/user/jabuschh/uhh2-106X_v2/CMSSW_10_6_28/src/UHH2/HOTVR/data/TopTaggingScaleFactors_RunIISummer19UL18_PUPPIv15.root"/> -->
 
 			<Item Name="NLOCorrections" Value = "/nfs/dust/cms/user/jabuschh/uhh2-106X_v2/CMSSW_10_6_28/src/UHH2/ZprimeSemiLeptonic/data/"/>
 
@@ -343,22 +344,20 @@
 			<Item Name="is_deepAK8" Value="&IS_DEEPAK8;"/>
 			<Item Name="is_looser_selection" Value="&IS_LOOSER_SELECTION;"/>
 
-			<Item Name="use_sframe_weight"    Value="false"/>
-			<Item Name="jersmear_direction"   Value="nominal"/>
-			<Item Name="jecsmear_direction"   Value="nominal"/>
-			<Item Name="ScaleVariationMuR"    Value="nominal"/>
-			<Item Name="ScaleVariationMuF"    Value="nominal"/>
-			<Item Name="Sys_MuonID_low"       Value="nominal"/>
-			<Item Name="Sys_MuonISO_low"      Value="nominal"/>
-			<Item Name="Sys_MuonID_high"      Value="nominal"/>
-			<Item Name="Sys_MuonTrigger_low"  Value="nominal"/>
-			<Item Name="Sys_MuonTrigger_high" Value="nominal"/>
-			<Item Name="Sys_EleID"            Value="nominal"/>
-			<Item Name="Sys_EleTrigger"       Value="nominal"/>
-			<Item Name="Sys_PU"               Value="central"/>
-			<Item Name="Sys_btag"             Value="central"/>
-			<Item Name="Sys_TopTag"           Value="nominal"/>
-			<Item Name="channel"              Value="&CHANNEL;"/>
+			<Item Name="use_sframe_weight"          Value="false"/>
+			<Item Name="jersmear_direction"         Value="nominal"/>
+			<Item Name="jecsmear_direction"         Value="nominal"/>
+			<Item Name="ScaleVariationMuR"          Value="nominal"/>
+			<Item Name="ScaleVariationMuF"          Value="nominal"/>
+			<Item Name="SystDirection_MuonIso"      Value="nominal"/>
+			<Item Name="SystDirection_MuonTrigger"  Value="nominal"/>
+			<Item Name="SystDirection_ElectronId"   Value="nominal"/>
+			<Item Name="SystDirection_ElectronReco" Value="nominal"/>
+			<!-- add electron trigger SFs -->
+			<Item Name="Sys_PU"                     Value="central"/>
+			<Item Name="Sys_btag"                   Value="central"/>
+			<Item Name="Sys_TopTag"                 Value="nominal"/>
+			<Item Name="channel"                    Value="&CHANNEL;"/>
 
 			<Item Name="additionalBranches"	   Value="jetsAk4CHS
 																								genjetsAk8SubstructureSoftDrop"/> <!-- ADDED ADDITIONAL CHS AK4 JETS FOR MATCHING, GEN JETS for AK8PUPPI -->

--- a/config/NonResAnalysis_106X_UL18_electron_UseNN.xml
+++ b/config/NonResAnalysis_106X_UL18_electron_UseNN.xml
@@ -344,36 +344,34 @@
 			<Item Name="is_deepAK8" Value="&IS_DEEPAK8;"/>
 			<Item Name="is_looser_selection" Value="&IS_LOOSER_SELECTION;"/>
 
-                        <Item Name="additionalBranches" Value=" Ak4_j1_E Ak4_j1_eta Ak4_j1_m Ak4_j1_phi Ak4_j1_pt Ak4_j1_deepjetbscore
-                                                                Ak4_j2_E Ak4_j2_eta Ak4_j2_m Ak4_j2_phi Ak4_j2_pt Ak4_j2_deepjetbscore
-                                                                Ak4_j3_E Ak4_j3_eta Ak4_j3_m Ak4_j3_phi Ak4_j3_pt Ak4_j3_deepjetbscore
-                                                                Ak4_j4_E Ak4_j4_eta Ak4_j4_m Ak4_j4_phi Ak4_j4_pt Ak4_j4_deepjetbscore
-                                                                Ak4_j5_E Ak4_j5_eta Ak4_j5_m Ak4_j5_phi Ak4_j5_pt Ak4_j5_deepjetbscore
-                                                                Ak4_j6_E Ak4_j6_eta Ak4_j6_m Ak4_j6_phi Ak4_j6_pt Ak4_j6_deepjetbscore
-                                                                Ak8_j1_E Ak8_j1_eta Ak8_j1_mSD Ak8_j1_phi Ak8_j1_pt Ak8_j1_tau21 Ak8_j1_tau32
-                                                                Ak8_j2_E Ak8_j2_eta Ak8_j2_mSD Ak8_j2_phi Ak8_j2_pt Ak8_j2_tau21 Ak8_j2_tau32
-                                                                Ak8_j3_E Ak8_j3_eta Ak8_j3_mSD Ak8_j3_phi Ak8_j3_pt Ak8_j3_tau21 Ak8_j3_tau32
-                                                                MET_phi MET_pt
-                                                                Ele_E Ele_eta Ele_phi Ele_pt
-                                                                N_Ak4 N_Ak8
-                                                                CHS_matched genjetsAk8SubstructureSoftDrop " />
+      <Item Name="additionalBranches" Value=" Ak4_j1_E Ak4_j1_eta Ak4_j1_m Ak4_j1_phi Ak4_j1_pt Ak4_j1_deepjetbscore
+                                              Ak4_j2_E Ak4_j2_eta Ak4_j2_m Ak4_j2_phi Ak4_j2_pt Ak4_j2_deepjetbscore
+                                              Ak4_j3_E Ak4_j3_eta Ak4_j3_m Ak4_j3_phi Ak4_j3_pt Ak4_j3_deepjetbscore
+                                              Ak4_j4_E Ak4_j4_eta Ak4_j4_m Ak4_j4_phi Ak4_j4_pt Ak4_j4_deepjetbscore
+                                              Ak4_j5_E Ak4_j5_eta Ak4_j5_m Ak4_j5_phi Ak4_j5_pt Ak4_j5_deepjetbscore
+                                              Ak4_j6_E Ak4_j6_eta Ak4_j6_m Ak4_j6_phi Ak4_j6_pt Ak4_j6_deepjetbscore
+                                              Ak8_j1_E Ak8_j1_eta Ak8_j1_mSD Ak8_j1_phi Ak8_j1_pt Ak8_j1_tau21 Ak8_j1_tau32
+                                              Ak8_j2_E Ak8_j2_eta Ak8_j2_mSD Ak8_j2_phi Ak8_j2_pt Ak8_j2_tau21 Ak8_j2_tau32
+                                              Ak8_j3_E Ak8_j3_eta Ak8_j3_mSD Ak8_j3_phi Ak8_j3_pt Ak8_j3_tau21 Ak8_j3_tau32
+                                              MET_phi MET_pt
+                                              Ele_E Ele_eta Ele_phi Ele_pt
+                                              N_Ak4 N_Ak8
+                                              CHS_matched genjetsAk8SubstructureSoftDrop " />
 
-			<Item Name="use_sframe_weight"    Value="false"/>
-			<Item Name="jersmear_direction"   Value="nominal"/>
-			<Item Name="jecsmear_direction"   Value="nominal"/>
-			<Item Name="ScaleVariationMuR"    Value="nominal"/>
-			<Item Name="ScaleVariationMuF"    Value="nominal"/>
-			<Item Name="Sys_MuonID_low"       Value="nominal"/>
-			<Item Name="Sys_MuonISO_low"      Value="nominal"/>
-			<Item Name="Sys_MuonID_high"      Value="nominal"/>
-			<Item Name="Sys_MuonTrigger_low"  Value="nominal"/>
-			<Item Name="Sys_MuonTrigger_high" Value="nominal"/>
-			<Item Name="Sys_EleID"            Value="nominal"/>
-			<Item Name="Sys_EleTrigger"       Value="nominal"/>
-			<Item Name="Sys_PU"               Value="central"/>
-			<Item Name="Sys_btag"             Value="central"/>
-			<Item Name="Sys_TopTag"           Value="nominal"/>
-			<Item Name="channel"              Value="&CHANNEL;"/>
+			<Item Name="use_sframe_weight"          Value="false"/>
+			<Item Name="jersmear_direction"         Value="nominal"/>
+			<Item Name="jecsmear_direction"         Value="nominal"/>
+			<Item Name="ScaleVariationMuR"          Value="nominal"/>
+			<Item Name="ScaleVariationMuF"          Value="nominal"/>
+			<Item Name="SystDirection_MuonIso"      Value="nominal"/>
+			<Item Name="SystDirection_MuonTrigger"  Value="nominal"/>
+			<Item Name="SystDirection_ElectronId"   Value="nominal"/>
+			<Item Name="SystDirection_ElectronReco" Value="nominal"/>
+			<!-- add electron trigger SFs -->
+			<Item Name="Sys_PU"                     Value="central"/>
+			<Item Name="Sys_btag"                   Value="central"/>
+			<Item Name="Sys_TopTag"                 Value="nominal"/>
+			<Item Name="channel"                    Value="&CHANNEL;"/>
 
 
 				<Item Name="AnalysisModule" Value="ZprimeAnalysisModule_applyNN"/>

--- a/config/NonResAnalysis_106X_UL18_muon.xml
+++ b/config/NonResAnalysis_106X_UL18_muon.xml
@@ -11,46 +11,47 @@
 <!ENTITY IS_LOOSER_SELECTION "false">
 <!ENTITY CHANNEL             "muon">
 <!ENTITY OUTPUTdir           "/nfs/dust/cms/group/zprime-uhh/Analysis_UL18/&CHANNEL;/">
+<!-- <!ENTITY OUTPUTdir           "/nfs/dust/cms/user/jabuschh/ZprimeSemiLeptonic/RunII_106X_v2/UL18/&CHANNEL;/"> -->
 
 <!-- DATA -->
-<!-- <!ENTITY DATA_SingleMuon_RunA_UL18_blinded SYSTEM  "../data/Skimming_datasets_UL18_preselection/"> -->
-<!ENTITY DATA_SingleMuon_RunB_UL18_blinded SYSTEM  "../data/Skimming_datasets_UL18_preselection/DATA_SingleMuon_RunB_UL18.xml">
-<!ENTITY DATA_SingleMuon_RunC_UL18_blinded SYSTEM  "../data/Skimming_datasets_UL18_preselection/DATA_SingleMuon_RunC_UL18.xml">
-<!ENTITY DATA_SingleMuon_RunD_UL18_blinded SYSTEM  "../data/Skimming_datasets_UL18_preselection/DATA_SingleMuon_RunD_UL18.xml">
+<!ENTITY DATA_SingleMuon_RunA_UL18_blinded SYSTEM "../data/Skimming_datasets_UL18_preselection/DATA_SingleMuon_RunB_UL18.xml">
+<!ENTITY DATA_SingleMuon_RunB_UL18_blinded SYSTEM "../data/Skimming_datasets_UL18_preselection/DATA_SingleMuon_RunB_UL18.xml">
+<!ENTITY DATA_SingleMuon_RunC_UL18_blinded SYSTEM "../data/Skimming_datasets_UL18_preselection/DATA_SingleMuon_RunC_UL18.xml">
+<!ENTITY DATA_SingleMuon_RunD_UL18_blinded SYSTEM "../data/Skimming_datasets_UL18_preselection/DATA_SingleMuon_RunD_UL18.xml">
 <!-- TTbar -->
-<!ENTITY TTToSemiLeptonic_UL18 SYSTEM  "../data/Skimming_datasets_UL18_preselection/TTToSemiLeptonic_UL18.xml">
-<!ENTITY TTToHadronic_UL18     SYSTEM  "../data/Skimming_datasets_UL18_preselection/TTToHadronic_UL18.xml">
-<!ENTITY TTTo2L2Nu_UL18        SYSTEM  "../data/Skimming_datasets_UL18_preselection/TTTo2L2Nu_UL18.xml">
+<!ENTITY TTToSemiLeptonic_UL18 SYSTEM "../data/Skimming_datasets_UL18_preselection/TTToSemiLeptonic_UL18.xml">
+<!ENTITY TTToHadronic_UL18     SYSTEM "../data/Skimming_datasets_UL18_preselection/TTToHadronic_UL18.xml">
+<!ENTITY TTTo2L2Nu_UL18        SYSTEM "../data/Skimming_datasets_UL18_preselection/TTTo2L2Nu_UL18.xml">
 <!-- WJets -->
-<!ENTITY WJetsToLNu_HT-70To100_UL18    SYSTEM  "../data/Skimming_datasets_UL18_preselection/WJetsToLNu_HT-70To100_UL18.xml">
-<!ENTITY WJetsToLNu_HT-100To200_UL18   SYSTEM  "../data/Skimming_datasets_UL18_preselection/WJetsToLNu_HT-100To200_UL18.xml">
-<!ENTITY WJetsToLNu_HT-200To400_UL18   SYSTEM  "../data/Skimming_datasets_UL18_preselection/WJetsToLNu_HT-200To400_UL18.xml">
-<!ENTITY WJetsToLNu_HT-400To600_UL18   SYSTEM  "../data/Skimming_datasets_UL18_preselection/WJetsToLNu_HT-400To600_UL18.xml">
-<!ENTITY WJetsToLNu_HT-600To800_UL18   SYSTEM  "../data/Skimming_datasets_UL18_preselection/WJetsToLNu_HT-600To800_UL18.xml">
-<!ENTITY WJetsToLNu_HT-800To1200_UL18  SYSTEM  "../data/Skimming_datasets_UL18_preselection/WJetsToLNu_HT-800To1200_UL18.xml">
-<!ENTITY WJetsToLNu_HT-1200To2500_UL18 SYSTEM  "../data/Skimming_datasets_UL18_preselection/WJetsToLNu_HT-1200To2500_UL18.xml">
-<!ENTITY WJetsToLNu_HT-2500ToInf_UL18  SYSTEM  "../data/Skimming_datasets_UL18_preselection/WJetsToLNu_HT-2500ToInf_UL18.xml">
+<!ENTITY WJetsToLNu_HT-70To100_UL18    SYSTEM "../data/Skimming_datasets_UL18_preselection/WJetsToLNu_HT-70To100_UL18.xml">
+<!ENTITY WJetsToLNu_HT-100To200_UL18   SYSTEM "../data/Skimming_datasets_UL18_preselection/WJetsToLNu_HT-100To200_UL18.xml">
+<!ENTITY WJetsToLNu_HT-200To400_UL18   SYSTEM "../data/Skimming_datasets_UL18_preselection/WJetsToLNu_HT-200To400_UL18.xml">
+<!ENTITY WJetsToLNu_HT-400To600_UL18   SYSTEM "../data/Skimming_datasets_UL18_preselection/WJetsToLNu_HT-400To600_UL18.xml">
+<!ENTITY WJetsToLNu_HT-600To800_UL18   SYSTEM "../data/Skimming_datasets_UL18_preselection/WJetsToLNu_HT-600To800_UL18.xml">
+<!ENTITY WJetsToLNu_HT-800To1200_UL18  SYSTEM "../data/Skimming_datasets_UL18_preselection/WJetsToLNu_HT-800To1200_UL18.xml">
+<!ENTITY WJetsToLNu_HT-1200To2500_UL18 SYSTEM "../data/Skimming_datasets_UL18_preselection/WJetsToLNu_HT-1200To2500_UL18.xml">
+<!ENTITY WJetsToLNu_HT-2500ToInf_UL18  SYSTEM "../data/Skimming_datasets_UL18_preselection/WJetsToLNu_HT-2500ToInf_UL18.xml">
 <!-- DY -->
-<!ENTITY DYJetsToLL_M-50_HT-70to100_UL18    SYSTEM  "../data/Skimming_datasets_UL18_preselection/DYJetsToLL_M-50_HT-70to100_UL18.xml">
-<!ENTITY DYJetsToLL_M-50_HT-100to200_UL18   SYSTEM  "../data/Skimming_datasets_UL18_preselection/DYJetsToLL_M-50_HT-100to200_UL18.xml">
-<!ENTITY DYJetsToLL_M-50_HT-200to400_UL18   SYSTEM  "../data/Skimming_datasets_UL18_preselection/DYJetsToLL_M-50_HT-200to400_UL18.xml">
-<!ENTITY DYJetsToLL_M-50_HT-400to600_UL18   SYSTEM  "../data/Skimming_datasets_UL18_preselection/DYJetsToLL_M-50_HT-400to600_UL18.xml">
-<!ENTITY DYJetsToLL_M-50_HT-600to800_UL18   SYSTEM  "../data/Skimming_datasets_UL18_preselection/DYJetsToLL_M-50_HT-600to800_UL18.xml">
-<!ENTITY DYJetsToLL_M-50_HT-800to1200_UL18  SYSTEM  "../data/Skimming_datasets_UL18_preselection/DYJetsToLL_M-50_HT-800to1200_UL18.xml">
-<!ENTITY DYJetsToLL_M-50_HT-1200to2500_UL18 SYSTEM  "../data/Skimming_datasets_UL18_preselection/DYJetsToLL_M-50_HT-1200to2500_UL18.xml">
-<!ENTITY DYJetsToLL_M-50_HT-2500toInf_UL18  SYSTEM  "../data/Skimming_datasets_UL18_preselection/DYJetsToLL_M-50_HT-2500toInf_UL18.xml">
+<!ENTITY DYJetsToLL_M-50_HT-70to100_UL18    SYSTEM "../data/Skimming_datasets_UL18_preselection/DYJetsToLL_M-50_HT-70to100_UL18.xml">
+<!ENTITY DYJetsToLL_M-50_HT-100to200_UL18   SYSTEM "../data/Skimming_datasets_UL18_preselection/DYJetsToLL_M-50_HT-100to200_UL18.xml">
+<!ENTITY DYJetsToLL_M-50_HT-200to400_UL18   SYSTEM "../data/Skimming_datasets_UL18_preselection/DYJetsToLL_M-50_HT-200to400_UL18.xml">
+<!ENTITY DYJetsToLL_M-50_HT-400to600_UL18   SYSTEM "../data/Skimming_datasets_UL18_preselection/DYJetsToLL_M-50_HT-400to600_UL18.xml">
+<!ENTITY DYJetsToLL_M-50_HT-600to800_UL18   SYSTEM "../data/Skimming_datasets_UL18_preselection/DYJetsToLL_M-50_HT-600to800_UL18.xml">
+<!ENTITY DYJetsToLL_M-50_HT-800to1200_UL18  SYSTEM "../data/Skimming_datasets_UL18_preselection/DYJetsToLL_M-50_HT-800to1200_UL18.xml">
+<!ENTITY DYJetsToLL_M-50_HT-1200to2500_UL18 SYSTEM "../data/Skimming_datasets_UL18_preselection/DYJetsToLL_M-50_HT-1200to2500_UL18.xml">
+<!ENTITY DYJetsToLL_M-50_HT-2500toInf_UL18  SYSTEM "../data/Skimming_datasets_UL18_preselection/DYJetsToLL_M-50_HT-2500toInf_UL18.xml">
 <!-- Diboson -->
-<!ENTITY WW_UL18 SYSTEM  "../data/Skimming_datasets_UL18_preselection/WW_UL18.xml">
-<!ENTITY WZ_UL18 SYSTEM  "../data/Skimming_datasets_UL18_preselection/WZ_UL18.xml">
-<!ENTITY ZZ_UL18 SYSTEM  "../data/Skimming_datasets_UL18_preselection/ZZ_UL18.xml">
+<!ENTITY WW_UL18 SYSTEM "../data/Skimming_datasets_UL18_preselection/WW_UL18.xml">
+<!ENTITY WZ_UL18 SYSTEM "../data/Skimming_datasets_UL18_preselection/WZ_UL18.xml">
+<!ENTITY ZZ_UL18 SYSTEM "../data/Skimming_datasets_UL18_preselection/ZZ_UL18.xml">
 <!-- ST -->
-<!ENTITY ST_tW_antitop_5f_inclusiveDecays_UL18        SYSTEM  "../data/Skimming_datasets_UL18_preselection/ST_tW_antitop_5f_inclusiveDecays_UL18.xml">
-<!ENTITY ST_tW_top_5f_inclusiveDecays_UL18            SYSTEM  "../data/Skimming_datasets_UL18_preselection/ST_tW_top_5f_inclusiveDecays_UL18.xml">
-<!ENTITY ST_tW_antitop_5f_NoFullyHadronicDecays_UL18  SYSTEM  "../data/Skimming_datasets_UL18_preselection/ST_tW_antitop_5f_NoFullyHadronicDecays_UL18.xml">
-<!ENTITY ST_tW_top_5f_NoFullyHadronicDecays_UL18      SYSTEM  "../data/Skimming_datasets_UL18_preselection/ST_tW_top_5f_NoFullyHadronicDecays_UL18.xml">
-<!ENTITY ST_t-channel_antitop_4f_InclusiveDecays_UL18 SYSTEM  "../data/Skimming_datasets_UL18_preselection/ST_t-channel_antitop_4f_InclusiveDecays_UL18.xml">
-<!ENTITY ST_t-channel_top_4f_InclusiveDecays_UL18     SYSTEM  "../data/Skimming_datasets_UL18_preselection/ST_t-channel_top_4f_InclusiveDecays_UL18.xml">
-<!ENTITY ST_s-channel_4f_leptonDecays_UL18            SYSTEM  "../data/Skimming_datasets_UL18_preselection/ST_s-channel_4f_leptonDecays_UL18.xml">
+<!ENTITY ST_tW_antitop_5f_inclusiveDecays_UL18        SYSTEM "../data/Skimming_datasets_UL18_preselection/ST_tW_antitop_5f_inclusiveDecays_UL18.xml">
+<!ENTITY ST_tW_top_5f_inclusiveDecays_UL18            SYSTEM "../data/Skimming_datasets_UL18_preselection/ST_tW_top_5f_inclusiveDecays_UL18.xml">
+<!ENTITY ST_tW_antitop_5f_NoFullyHadronicDecays_UL18  SYSTEM "../data/Skimming_datasets_UL18_preselection/ST_tW_antitop_5f_NoFullyHadronicDecays_UL18.xml">
+<!ENTITY ST_tW_top_5f_NoFullyHadronicDecays_UL18      SYSTEM "../data/Skimming_datasets_UL18_preselection/ST_tW_top_5f_NoFullyHadronicDecays_UL18.xml">
+<!ENTITY ST_t-channel_antitop_4f_InclusiveDecays_UL18 SYSTEM "../data/Skimming_datasets_UL18_preselection/ST_t-channel_antitop_4f_InclusiveDecays_UL18.xml">
+<!ENTITY ST_t-channel_top_4f_InclusiveDecays_UL18     SYSTEM "../data/Skimming_datasets_UL18_preselection/ST_t-channel_top_4f_InclusiveDecays_UL18.xml">
+<!ENTITY ST_s-channel_4f_leptonDecays_UL18            SYSTEM "../data/Skimming_datasets_UL18_preselection/ST_s-channel_4f_leptonDecays_UL18.xml">
 <!-- QCD -->
 <!ENTITY QCD_HT50to100_UL18    SYSTEM "../data/Skimming_datasets_UL18_preselection/QCD_HT50to100_UL18.xml">
 <!ENTITY QCD_HT100to200_UL18   SYSTEM "../data/Skimming_datasets_UL18_preselection/QCD_HT100to200_UL18.xml">
@@ -335,7 +336,7 @@
 
 			<Item Name="MCBtagEfficiencies" Value = "/nfs/dust/cms/user/jabuschh/uhh2-106X_v2/CMSSW_10_6_28/src/UHH2/ZprimeSemiLeptonic/data/2018/BTagMCEfficiencyHists_muon2018.root"/>
 			<Item Name="BTagCalibration"    Value = "/nfs/dust/cms/user/jabuschh/uhh2-106X_v2/CMSSW_10_6_28/src/UHH2/common/UHH2-data/UL18/reshaping_deepJet_106XUL18_v2.csv"/> <!-- reshape -->
-			<Item Name="HOTVRTopTagSFs"     Value = "/nfs/dust/cms/user/jabuschh/uhh2-106X_v2/CMSSW_10_6_28/src/UHH2/HOTVR/data/TopTaggingScaleFactors_RunIISummer19UL18_PUPPIv15.root"/>
+			<!-- <Item Name="HOTVRTopTagSFs"     Value = "/nfs/dust/cms/user/jabuschh/uhh2-106X_v2/CMSSW_10_6_28/src/UHH2/HOTVR/data/TopTaggingScaleFactors_RunIISummer19UL18_PUPPIv15.root"/> -->
 
 			<Item Name="NLOCorrections" Value = "/nfs/dust/cms/user/jabuschh/uhh2-106X_v2/CMSSW_10_6_28/src/UHH2/ZprimeSemiLeptonic/data/"/>
 
@@ -343,22 +344,20 @@
 			<Item Name="is_deepAK8" Value="&IS_DEEPAK8;"/>
 			<Item Name="is_looser_selection" Value="&IS_LOOSER_SELECTION;"/>
 
-			<Item Name="use_sframe_weight"    Value="false"/>
-			<Item Name="jersmear_direction"   Value="nominal"/>
-			<Item Name="jecsmear_direction"   Value="nominal"/>
-			<Item Name="ScaleVariationMuR"    Value="nominal"/>
-			<Item Name="ScaleVariationMuF"    Value="nominal"/>
-			<Item Name="Sys_MuonID_low"       Value="nominal"/>
-			<Item Name="Sys_MuonISO_low"      Value="nominal"/>
-			<Item Name="Sys_MuonID_high"      Value="nominal"/>
-			<Item Name="Sys_MuonTrigger_low"  Value="nominal"/>
-			<Item Name="Sys_MuonTrigger_high" Value="nominal"/>
-			<Item Name="Sys_EleID"            Value="nominal"/>
-			<Item Name="Sys_EleTrigger"       Value="nominal"/>
-			<Item Name="Sys_PU"               Value="central"/>
-			<Item Name="Sys_btag"             Value="central"/>
-			<Item Name="Sys_TopTag"           Value="nominal"/>
-			<Item Name="channel"              Value="&CHANNEL;"/>
+			<Item Name="use_sframe_weight"          Value="false"/>
+			<Item Name="jersmear_direction"         Value="nominal"/>
+			<Item Name="jecsmear_direction"         Value="nominal"/>
+			<Item Name="ScaleVariationMuR"          Value="nominal"/>
+			<Item Name="ScaleVariationMuF"          Value="nominal"/>
+			<Item Name="SystDirection_MuonIso"      Value="nominal"/>
+			<Item Name="SystDirection_MuonTrigger"  Value="nominal"/>
+			<Item Name="SystDirection_ElectronId"   Value="nominal"/>
+			<Item Name="SystDirection_ElectronReco" Value="nominal"/>
+			<!-- add electron trigger SFs -->
+			<Item Name="Sys_PU"                     Value="central"/>
+			<Item Name="Sys_btag"                   Value="central"/>
+			<Item Name="Sys_TopTag"                 Value="nominal"/>
+			<Item Name="channel"                    Value="&CHANNEL;"/>
 
 			<Item Name="additionalBranches"	   Value="jetsAk4CHS
 																								genjetsAk8SubstructureSoftDrop"/> <!-- ADDED ADDITIONAL CHS AK4 JETS FOR MATCHING, GEN JETS for AK8PUPPI -->

--- a/config/NonResAnalysis_106X_UL18_muon_UseNN.xml
+++ b/config/NonResAnalysis_106X_UL18_muon_UseNN.xml
@@ -345,36 +345,34 @@
 			<Item Name="is_deepAK8" Value="&IS_DEEPAK8;"/>
 			<Item Name="is_looser_selection" Value="&IS_LOOSER_SELECTION;"/>
 
-                        <Item Name="additionalBranches" Value=" Ak4_j1_E Ak4_j1_eta Ak4_j1_m Ak4_j1_phi Ak4_j1_pt Ak4_j1_deepjetbscore
-                                                                Ak4_j2_E Ak4_j2_eta Ak4_j2_m Ak4_j2_phi Ak4_j2_pt Ak4_j2_deepjetbscore
-                                                                Ak4_j3_E Ak4_j3_eta Ak4_j3_m Ak4_j3_phi Ak4_j3_pt Ak4_j3_deepjetbscore
-                                                                Ak4_j4_E Ak4_j4_eta Ak4_j4_m Ak4_j4_phi Ak4_j4_pt Ak4_j4_deepjetbscore
-                                                                Ak4_j5_E Ak4_j5_eta Ak4_j5_m Ak4_j5_phi Ak4_j5_pt Ak4_j5_deepjetbscore
-                                                                Ak4_j6_E Ak4_j6_eta Ak4_j6_m Ak4_j6_phi Ak4_j6_pt Ak4_j6_deepjetbscore
-                                                                Ak8_j1_E Ak8_j1_eta Ak8_j1_mSD Ak8_j1_phi Ak8_j1_pt Ak8_j1_tau21 Ak8_j1_tau32
-                                                                Ak8_j2_E Ak8_j2_eta Ak8_j2_mSD Ak8_j2_phi Ak8_j2_pt Ak8_j2_tau21 Ak8_j2_tau32
-                                                                Ak8_j3_E Ak8_j3_eta Ak8_j3_mSD Ak8_j3_phi Ak8_j3_pt Ak8_j3_tau21 Ak8_j3_tau32
-                                                                MET_phi MET_pt
-                                                                Mu_E Mu_eta Mu_phi Mu_pt
-                                                                N_Ak4 N_Ak8
-                                                                CHS_matched genjetsAk8SubstructureSoftDrop " />
+      <Item Name="additionalBranches" Value=" Ak4_j1_E Ak4_j1_eta Ak4_j1_m Ak4_j1_phi Ak4_j1_pt Ak4_j1_deepjetbscore
+                                              Ak4_j2_E Ak4_j2_eta Ak4_j2_m Ak4_j2_phi Ak4_j2_pt Ak4_j2_deepjetbscore
+                                              Ak4_j3_E Ak4_j3_eta Ak4_j3_m Ak4_j3_phi Ak4_j3_pt Ak4_j3_deepjetbscore
+                                              Ak4_j4_E Ak4_j4_eta Ak4_j4_m Ak4_j4_phi Ak4_j4_pt Ak4_j4_deepjetbscore
+                                              Ak4_j5_E Ak4_j5_eta Ak4_j5_m Ak4_j5_phi Ak4_j5_pt Ak4_j5_deepjetbscore
+                                              Ak4_j6_E Ak4_j6_eta Ak4_j6_m Ak4_j6_phi Ak4_j6_pt Ak4_j6_deepjetbscore
+                                              Ak8_j1_E Ak8_j1_eta Ak8_j1_mSD Ak8_j1_phi Ak8_j1_pt Ak8_j1_tau21 Ak8_j1_tau32
+                                              Ak8_j2_E Ak8_j2_eta Ak8_j2_mSD Ak8_j2_phi Ak8_j2_pt Ak8_j2_tau21 Ak8_j2_tau32
+                                              Ak8_j3_E Ak8_j3_eta Ak8_j3_mSD Ak8_j3_phi Ak8_j3_pt Ak8_j3_tau21 Ak8_j3_tau32
+                                              MET_phi MET_pt
+                                              Mu_E Mu_eta Mu_phi Mu_pt
+                                              N_Ak4 N_Ak8
+                                              CHS_matched genjetsAk8SubstructureSoftDrop " />
 
-			<Item Name="use_sframe_weight"    Value="false"/>
-			<Item Name="jersmear_direction"   Value="nominal"/>
-			<Item Name="jecsmear_direction"   Value="nominal"/>
-			<Item Name="ScaleVariationMuR"    Value="nominal"/>
-			<Item Name="ScaleVariationMuF"    Value="nominal"/>
-			<Item Name="Sys_MuonID_low"       Value="nominal"/>
-			<Item Name="Sys_MuonISO_low"      Value="nominal"/>
-			<Item Name="Sys_MuonID_high"      Value="nominal"/>
-			<Item Name="Sys_MuonTrigger_low"  Value="nominal"/>
-			<Item Name="Sys_MuonTrigger_high" Value="nominal"/>
-			<Item Name="Sys_EleID"            Value="nominal"/>
-			<Item Name="Sys_EleTrigger"       Value="nominal"/>
-			<Item Name="Sys_PU"               Value="central"/>
-			<Item Name="Sys_btag"             Value="central"/>
-			<Item Name="Sys_TopTag"           Value="nominal"/>
-			<Item Name="channel"              Value="&CHANNEL;"/>
+			<Item Name="use_sframe_weight"          Value="false"/>
+			<Item Name="jersmear_direction"         Value="nominal"/>
+			<Item Name="jecsmear_direction"         Value="nominal"/>
+			<Item Name="ScaleVariationMuR"          Value="nominal"/>
+			<Item Name="ScaleVariationMuF"          Value="nominal"/>
+			<Item Name="SystDirection_MuonIso"      Value="nominal"/>
+			<Item Name="SystDirection_MuonTrigger"  Value="nominal"/>
+			<Item Name="SystDirection_ElectronId"   Value="nominal"/>
+			<Item Name="SystDirection_ElectronReco" Value="nominal"/>
+			<!-- add electron trigger SFs -->
+			<Item Name="Sys_PU"                     Value="central"/>
+			<Item Name="Sys_btag"                   Value="central"/>
+			<Item Name="Sys_TopTag"                 Value="nominal"/>
+			<Item Name="channel"                    Value="&CHANNEL;"/>
 
 
 				<Item Name="AnalysisModule" Value="ZprimeAnalysisModule_applyNN"/>

--- a/config/NonResPreselection_106X_UL18.xml
+++ b/config/NonResPreselection_106X_UL18.xml
@@ -13,7 +13,7 @@
 <!ENTITY DATA_EGamma_RunB_UL18     SYSTEM  "../../common/UHH2-datasets/RunII_106X_v2/data/UL18/EGamma_Run2018B-UL2018_MiniAODv2-v1.xml">
 <!ENTITY DATA_EGamma_RunC_UL18     SYSTEM  "../../common/UHH2-datasets/RunII_106X_v2/data/UL18/EGamma_Run2018C-UL2018_MiniAODv2-v1.xml">
 <!ENTITY DATA_EGamma_RunD_UL18     SYSTEM  "../../common/UHH2-datasets/RunII_106X_v2/data/UL18/EGamma_Run2018D-UL2018_MiniAODv2-v2.xml">
-<!-- <!ENTITY DATA_SingleMuon_RunA_UL18 SYSTEM  "../../common/UHH2-datasets/RunII_106X_v2/data/UL18/"> TODO: still missing in DAS -->
+<!ENTITY DATA_SingleMuon_RunA_UL18 SYSTEM  "../../common/UHH2-datasets/RunII_106X_v2/data/UL18/SingleMuon_Run2018A-UL2018_MiniAODv2-v3.xml">
 <!ENTITY DATA_SingleMuon_RunB_UL18 SYSTEM  "../../common/UHH2-datasets/RunII_106X_v2/data/UL18/SingleMuon_Run2018B-UL2018_MiniAODv2-v2.xml">
 <!ENTITY DATA_SingleMuon_RunC_UL18 SYSTEM  "../../common/UHH2-datasets/RunII_106X_v2/data/UL18/SingleMuon_Run2018C-UL2018_MiniAODv2-v2.xml">
 <!ENTITY DATA_SingleMuon_RunD_UL18 SYSTEM  "../../common/UHH2-datasets/RunII_106X_v2/data/UL18/SingleMuon_Run2018D-UL2018_MiniAODv2-v3.xml">
@@ -68,7 +68,7 @@
 
 <!--
 <ConfigParse NEventsBreak="0" LastBreak="0" FileSplit="50" AutoResubmit="0"/>
-<ConfigSGE RAM="2" DISK="2" Mail="henrik.jabusch@desy.de" Notification="as" Workdir="workdir_Zprime_Preselection_UL18_ZZ"/>
+<ConfigSGE RAM="2" DISK="2" Mail="henrik.jabusch@desy.de" Notification="as" Workdir="workdir_Zprime_Preselection_UL18"/>
 -->
 
 <JobConfiguration JobName="ZprimePreselectionJob" OutputLevel="INFO">

--- a/src/ZprimeAnalysisModule_applyNN.cxx
+++ b/src/ZprimeAnalysisModule_applyNN.cxx
@@ -28,6 +28,7 @@
 #include <UHH2/common/include/EventHists.h>
 #include <UHH2/common/include/TopPtReweight.h>
 #include <UHH2/common/include/CommonModules.h>
+#include <UHH2/common/include/LeptonScaleFactors.h>
 
 #include <UHH2/ZprimeSemiLeptonic/include/ModuleBASE.h>
 #include <UHH2/ZprimeSemiLeptonic/include/ZprimeSemiLeptonicSelections.h>
@@ -275,8 +276,8 @@ void NeuralNetworkModule::CreateInputs(Event & event){
 
   //Only Ele or Mu variables!!
 
-// vector<uhh2::Event::Handle<float>> inputs = { h_Ak4_j1_E, h_Ak4_j1_deepjetbscore, h_Ak4_j1_eta, h_Ak4_j1_m, h_Ak4_j1_phi, h_Ak4_j1_pt,h_Ak4_j2_E,h_Ak4_j2_deepjetbscore,h_Ak4_j2_eta,h_Ak4_j2_m,h_Ak4_j2_phi,h_Ak4_j2_pt,h_Ak4_j3_E,h_Ak4_j3_deepjetbscore,h_Ak4_j3_eta,h_Ak4_j3_m,h_Ak4_j3_phi, h_Ak4_j3_pt,  h_Ak4_j4_E, h_Ak4_j4_deepjetbscore,  h_Ak4_j4_eta, h_Ak4_j4_m,   h_Ak4_j4_phi, h_Ak4_j4_pt,  h_Ak4_j5_E, h_Ak4_j5_deepjetbscore,  h_Ak4_j5_eta, h_Ak4_j5_m,   h_Ak4_j5_phi, h_Ak4_j5_pt,  h_Ak4_j6_E, h_Ak4_j6_deepjetbscore,  h_Ak4_j6_eta, h_Ak4_j6_m,   h_Ak4_j6_phi, h_Ak4_j6_pt,  h_Ak8_j1_E,     h_Ak8_j1_eta,   h_Ak8_j1_mSD,   h_Ak8_j1_phi,   h_Ak8_j1_pt,    h_Ak8_j1_tau21, h_Ak8_j1_tau32, h_Ak8_j2_E,     h_Ak8_j2_eta,   h_Ak8_j2_mSD,   h_Ak8_j2_phi,   h_Ak8_j2_pt,    h_Ak8_j2_tau21, h_Ak8_j2_tau32, h_Ak8_j3_E,     h_Ak8_j3_eta,   h_Ak8_j3_mSD,   h_Ak8_j3_phi,h_Ak8_j3_pt,h_Ak8_j3_tau21,h_Ak8_j3_tau32,h_MET_phi,h_MET_pt,h_Mu_E,  h_Mu_eta,h_Mu_phi,h_Mu_pt, h_N_Ak4,h_N_Ak8 };
-vector<uhh2::Event::Handle<float>> inputs = { h_Ak4_j1_E, h_Ak4_j1_deepjetbscore, h_Ak4_j1_eta, h_Ak4_j1_m, h_Ak4_j1_phi, h_Ak4_j1_pt,h_Ak4_j2_E,h_Ak4_j2_deepjetbscore,h_Ak4_j2_eta,h_Ak4_j2_m,h_Ak4_j2_phi,h_Ak4_j2_pt,h_Ak4_j3_E,h_Ak4_j3_deepjetbscore,h_Ak4_j3_eta,h_Ak4_j3_m,h_Ak4_j3_phi, h_Ak4_j3_pt,  h_Ak4_j4_E, h_Ak4_j4_deepjetbscore,  h_Ak4_j4_eta, h_Ak4_j4_m,   h_Ak4_j4_phi, h_Ak4_j4_pt,  h_Ak4_j5_E, h_Ak4_j5_deepjetbscore,  h_Ak4_j5_eta, h_Ak4_j5_m,   h_Ak4_j5_phi, h_Ak4_j5_pt,  h_Ak4_j6_E, h_Ak4_j6_deepjetbscore,  h_Ak4_j6_eta, h_Ak4_j6_m,   h_Ak4_j6_phi, h_Ak4_j6_pt,  h_Ak8_j1_E,     h_Ak8_j1_eta,   h_Ak8_j1_mSD,   h_Ak8_j1_phi,   h_Ak8_j1_pt,    h_Ak8_j1_tau21, h_Ak8_j1_tau32, h_Ak8_j2_E,     h_Ak8_j2_eta,   h_Ak8_j2_mSD,   h_Ak8_j2_phi,   h_Ak8_j2_pt,    h_Ak8_j2_tau21, h_Ak8_j2_tau32, h_Ak8_j3_E,     h_Ak8_j3_eta,   h_Ak8_j3_mSD,   h_Ak8_j3_phi,h_Ak8_j3_pt,h_Ak8_j3_tau21,h_Ak8_j3_tau32,h_Ele_E, h_Ele_eta, h_Ele_phi, h_Ele_pt, h_MET_phi,h_MET_pt,h_N_Ak4,h_N_Ak8 };
+  // vector<uhh2::Event::Handle<float>> inputs = { h_Ak4_j1_E, h_Ak4_j1_deepjetbscore, h_Ak4_j1_eta, h_Ak4_j1_m, h_Ak4_j1_phi, h_Ak4_j1_pt,h_Ak4_j2_E,h_Ak4_j2_deepjetbscore,h_Ak4_j2_eta,h_Ak4_j2_m,h_Ak4_j2_phi,h_Ak4_j2_pt,h_Ak4_j3_E,h_Ak4_j3_deepjetbscore,h_Ak4_j3_eta,h_Ak4_j3_m,h_Ak4_j3_phi, h_Ak4_j3_pt,  h_Ak4_j4_E, h_Ak4_j4_deepjetbscore,  h_Ak4_j4_eta, h_Ak4_j4_m,   h_Ak4_j4_phi, h_Ak4_j4_pt,  h_Ak4_j5_E, h_Ak4_j5_deepjetbscore,  h_Ak4_j5_eta, h_Ak4_j5_m,   h_Ak4_j5_phi, h_Ak4_j5_pt,  h_Ak4_j6_E, h_Ak4_j6_deepjetbscore,  h_Ak4_j6_eta, h_Ak4_j6_m,   h_Ak4_j6_phi, h_Ak4_j6_pt,  h_Ak8_j1_E,     h_Ak8_j1_eta,   h_Ak8_j1_mSD,   h_Ak8_j1_phi,   h_Ak8_j1_pt,    h_Ak8_j1_tau21, h_Ak8_j1_tau32, h_Ak8_j2_E,     h_Ak8_j2_eta,   h_Ak8_j2_mSD,   h_Ak8_j2_phi,   h_Ak8_j2_pt,    h_Ak8_j2_tau21, h_Ak8_j2_tau32, h_Ak8_j3_E,     h_Ak8_j3_eta,   h_Ak8_j3_mSD,   h_Ak8_j3_phi,h_Ak8_j3_pt,h_Ak8_j3_tau21,h_Ak8_j3_tau32,h_MET_phi,h_MET_pt,h_Mu_E,  h_Mu_eta,h_Mu_phi,h_Mu_pt, h_N_Ak4,h_N_Ak8 };
+  vector<uhh2::Event::Handle<float>> inputs = { h_Ak4_j1_E, h_Ak4_j1_deepjetbscore, h_Ak4_j1_eta, h_Ak4_j1_m, h_Ak4_j1_phi, h_Ak4_j1_pt,h_Ak4_j2_E,h_Ak4_j2_deepjetbscore,h_Ak4_j2_eta,h_Ak4_j2_m,h_Ak4_j2_phi,h_Ak4_j2_pt,h_Ak4_j3_E,h_Ak4_j3_deepjetbscore,h_Ak4_j3_eta,h_Ak4_j3_m,h_Ak4_j3_phi, h_Ak4_j3_pt,  h_Ak4_j4_E, h_Ak4_j4_deepjetbscore,  h_Ak4_j4_eta, h_Ak4_j4_m,   h_Ak4_j4_phi, h_Ak4_j4_pt,  h_Ak4_j5_E, h_Ak4_j5_deepjetbscore,  h_Ak4_j5_eta, h_Ak4_j5_m,   h_Ak4_j5_phi, h_Ak4_j5_pt,  h_Ak4_j6_E, h_Ak4_j6_deepjetbscore,  h_Ak4_j6_eta, h_Ak4_j6_m,   h_Ak4_j6_phi, h_Ak4_j6_pt,  h_Ak8_j1_E,     h_Ak8_j1_eta,   h_Ak8_j1_mSD,   h_Ak8_j1_phi,   h_Ak8_j1_pt,    h_Ak8_j1_tau21, h_Ak8_j1_tau32, h_Ak8_j2_E,     h_Ak8_j2_eta,   h_Ak8_j2_mSD,   h_Ak8_j2_phi,   h_Ak8_j2_pt,    h_Ak8_j2_tau21, h_Ak8_j2_tau32, h_Ak8_j3_E,     h_Ak8_j3_eta,   h_Ak8_j3_mSD,   h_Ak8_j3_phi,h_Ak8_j3_pt,h_Ak8_j3_tau21,h_Ak8_j3_tau32,h_Ele_E, h_Ele_eta, h_Ele_phi, h_Ele_pt, h_MET_phi,h_MET_pt,h_N_Ak4,h_N_Ak8 };
 
   for(int i = 0; i < 65; ++i){
     NNInputs.at(0).tensor<float, 2>()(0,i)  = (event.get(inputs.at(i))   - mean_val[i]) / (std_val[i]);
@@ -299,9 +300,11 @@ protected:
 
   bool debug;
 
-  // Scale Factors -- Systematics
-  unique_ptr<MCMuonScaleFactor> MuonID_module_low, MuonISO_module_low, MuonID_module_high, MuonTrigger_module_low, MuonTrigger_module_high;
-  unique_ptr<MCElecScaleFactor> EleID_module, EleTrigger_module;
+  // scale factors - systematics: new
+  unique_ptr<AnalysisModule> sf_muon_iso_low, sf_muon_iso_high, sf_muon_trigger_low, sf_muon_trigger_high;
+  unique_ptr<AnalysisModule> sf_muon_iso_low_dummy, sf_muon_iso_high_dummy, sf_muon_trigger_low_dummy, sf_muon_trigger_high_dummy;
+  unique_ptr<AnalysisModule> sf_ele_id_low, sf_ele_id_high, sf_ele_reco, sf_ele_trigger_low, sf_ele_trigger_high;
+  unique_ptr<AnalysisModule> sf_ele_id_low_dummy, sf_ele_id_high_dummy, sf_ele_reco_dummy, sf_ele_trigger_low_dummy, sf_ele_trigger_high_dummy;
 
   // AnalysisModules
   unique_ptr<AnalysisModule> LumiWeight_module, PUWeight_module, TopPtReweight_module, MCScale_module;
@@ -323,7 +326,7 @@ protected:
 
   // Selections
   unique_ptr<Selection> MuonVeto_selection, EleVeto_selection, NMuon1_LowPt_selection, NMuon1_HighPt_selection, NEle1_LowPt_selection, NEle1_HighPt_selection;
-  unique_ptr<Selection> Trigger_mu_A_selection, Trigger_mu_B_selection, Trigger_mu_C_selection, Trigger_mu_D_selection;
+  unique_ptr<Selection> Trigger_mu_A_selection, Trigger_mu_B_selection, Trigger_mu_C_selection, Trigger_mu_D_selection, Trigger_mu_E_selection, Trigger_mu_F_selection;
   unique_ptr<Selection> Trigger_ele_A_selection, Trigger_ele_B_selection, Trigger_ph_A_selection;
   unique_ptr<Selection> TwoDCut_selection, Jet1_selection, Jet2_selection, Met_selection, Chi2_selection1, Chi2_selection2, TTbarMatchable_selection, Chi2CandidateMatched_selection, ZprimeTopTag_selection, BlindData_selection;
   std::unique_ptr<uhh2::Selection> met_sel;
@@ -347,14 +350,8 @@ protected:
 
   uhh2::Event::Handle<ZprimeCandidate*> h_BestZprimeCandidateChi2;
 
-  // Set handles for mu iso sf - necessary for high pt muons, where no ISO SF are applied
-  uhh2::Event::Handle<float> h_musf_iso;
-  uhh2::Event::Handle<float> h_musf_iso_up;
-  uhh2::Event::Handle<float> h_musf_iso_down;
-
   // Lumi hists
   std::unique_ptr<Hists> lumihists_Weights_Init, lumihists_Weights_PU, lumihists_Weights_Lumi, lumihists_Weights_TopPt, lumihists_Weights_MCScale, lumihists_Muon1_LowPt, lumihists_Muon1_HighPt, lumihists_Ele1_LowPt, lumihists_Ele1_HighPt, lumihists_TriggerMuon, lumihists_TriggerEle, lumihists_TwoDCut_Muon, lumihists_TwoDCut_Ele, lumihists_Jet1, lumihists_Jet2, lumihists_MET, lumihists_HTlep, lumihists_Chi2;
-
 
   float inv_mass(const LorentzVector& p4){ return p4.isTimelike() ? p4.mass() : -sqrt(-p4.mass2()); }
 
@@ -516,7 +513,7 @@ ZprimeAnalysisModule_applyNN::ZprimeAnalysisModule_applyNN(uhh2::Context& ctx){
   double chi2_max1(100.);
   double chi2_max2(30.);
   double mtt_blind(3000.);
-  string trigger_mu_A, trigger_mu_B, trigger_mu_C, trigger_mu_D;
+  string trigger_mu_A, trigger_mu_B, trigger_mu_C, trigger_mu_D, trigger_mu_E, trigger_mu_F;
   string trigger_ele_A, trigger_ele_B;
   string trigger_ph_A;
   double MET_cut, HT_lep_cut;
@@ -534,6 +531,8 @@ ZprimeAnalysisModule_applyNN::ZprimeAnalysisModule_applyNN(uhh2::Context& ctx){
     trigger_mu_B = "HLT_IsoTkMu24_v*";
     trigger_mu_C = "HLT_Mu50_v*";
     trigger_mu_D = "HLT_TkMu50_v*";
+    trigger_mu_E = "HLT_OldMu100_v*";
+    trigger_mu_F = "HLT_TkMu100_v*";
 
     MET_cut = 50;
     HT_lep_cut = 0;
@@ -579,13 +578,6 @@ ZprimeAnalysisModule_applyNN::ZprimeAnalysisModule_applyNN(uhh2::Context& ctx){
   const ElectronId electronID_high(PtEtaSCCut(electron_pt_high, 2.5));
   const TopJetId toptagID = AndId<TopJet>(HOTVRTopTag(0.8, 140.0, 220.0, 50.0), Tau32Groomed(0.56));
 
-  Sys_MuonID_low = ctx.get("Sys_MuonID_low");
-  Sys_MuonISO_low = ctx.get("Sys_MuonISO_low");
-  Sys_MuonID_high = ctx.get("Sys_MuonID_high");
-  Sys_MuonTrigger_low = ctx.get("Sys_MuonTrigger_low");
-  Sys_MuonTrigger_high = ctx.get("Sys_MuonTrigger_high");
-  Sys_EleID = ctx.get("Sys_EleID");
-  Sys_EleTrigger = ctx.get("Sys_EleTrigger");
   Sys_PU = ctx.get("Sys_PU");
   Sys_btag = ctx.get("Sys_btag");
 
@@ -606,42 +598,24 @@ ZprimeAnalysisModule_applyNN::ZprimeAnalysisModule_applyNN(uhh2::Context& ctx){
   Corrections_module.reset(new NLOCorrections(ctx));
   //CustomBTagWeight_module.reset(new CustomMCBTagDiscriminantReweighting(ctx, btag_algo, "jets", Sys_btag,"iterativefit","","BTagCalibration"));
 
-  if((isUL16preVFP || isUL16postVFP) && isMuon){
-    MuonID_module_low      .reset(new MCMuonScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2016/MuonID_EfficienciesAndSF_average_RunBtoH.root"     , "NUM_TightID_DEN_genTracks_eta_pt"              , 1.0, "tightID"  , false, Sys_MuonID_low));
-    MuonISO_module_low     .reset(new MCMuonScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2016/MuonIso_EfficienciesAndSF_average_RunBtoH.root"    , "NUM_TightRelIso_DEN_TightIDandIPCut_eta_pt"    , 1.0, "isolation", false, Sys_MuonISO_low));
-    MuonID_module_high     .reset(new MCMuonScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2016/MuonID_EfficienciesAndSF_average_RunBtoH.root"     , "NUM_TightID_DEN_genTracks_eta_pt"              , 1.0, "tightID"  , false, Sys_MuonID_high));
-    MuonTrigger_module_low .reset(new MCMuonScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2016/MuonTrigger_EfficienciesAndSF_average_RunBtoH.root", "IsoMu24_OR_IsoTkMu24_PtEtaBins/pt_abseta_ratio", 0.5, "Trigger"  , true , Sys_MuonTrigger_low));
-    MuonTrigger_module_high.reset(new MCMuonScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2016/MuonTrigger_EfficienciesAndSF_average_RunBtoH.root", "IsoMu50_OR_IsoTkMu50_PtEtaBins/pt_abseta_ratio", 0.5, "Trigger"  , true , Sys_MuonTrigger_high));
-  }
 
-  if(isUL17 && isMuon){
-    MuonID_module_low      .reset(new MCMuonScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2017/MuonID_94X_RunBCDEF_SF_ID.root"                         , "NUM_TightID_DEN_genTracks_pt_abseta"          , 1.0, "tightID"  , true, Sys_MuonID_low));
-    MuonISO_module_low     .reset(new MCMuonScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2017/MuonIso_94X_RunBCDEF_SF_ISO.root"                       , "NUM_TightRelIso_DEN_TightIDandIPCut_pt_abseta", 1.0, "isolation", true, Sys_MuonISO_low));
-    MuonID_module_high     .reset(new MCMuonScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2017/MuonID_94X_RunBCDEF_SF_ID.root"                         , "NUM_TightID_DEN_genTracks_pt_abseta"          , 1.0, "tightID"  , true, Sys_MuonID_high));
-    MuonTrigger_module_low .reset(new MCMuonScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2017/MuonTrigger_EfficienciesAndSF_RunBtoF_Nov17Nov2017.root", "IsoMu27_PtEtaBins/pt_abseta_ratio"            , 0.5, "Trigger"  , true, Sys_MuonTrigger_low));
-    MuonTrigger_module_high.reset(new MCMuonScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2017/MuonTrigger_EfficienciesAndSF_RunBtoF_Nov17Nov2017.root", "Mu50_PtEtaBins/pt_abseta_ratio"               , 0.5, "Trigger"  , true, Sys_MuonTrigger_high));
-  }
+  // set lepton scale factors: see common/include/LeptonScaleFactors.{h,cxx}
+  sf_muon_iso_low.reset(new uhh2::MuonIsoScaleFactors(ctx, Muon::Selector::PFIsoTight, Muon::Selector::CutBasedIdTight));
+  sf_muon_iso_high.reset(new uhh2::MuonIsoScaleFactors(ctx, Muon::Selector::TkIsoLoose, Muon::Selector::CutBasedIdGlobalHighPt));
+  sf_muon_trigger_low.reset(new uhh2::MuonTriggerScaleFactors(ctx, false, true));
+  sf_muon_trigger_high.reset(new uhh2::MuonTriggerScaleFactors(ctx, true, true));
+  sf_ele_id_low.reset(new uhh2::ElectronIdScaleFactors(ctx, Electron::tag::mvaEleID_Fall17_iso_V2_wp80, true));
+  sf_ele_id_high.reset(new uhh2::ElectronIdScaleFactors(ctx, Electron::tag::mvaEleID_Fall17_noIso_V2_wp80, true));
+  sf_ele_reco.reset(new uhh2::ElectronRecoScaleFactors(ctx, false, true));
 
-  if(isUL18 && isMuon){
-    MuonID_module_low      .reset(new MCMuonScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2018/Muon_ID_SF_RunABCD.root"                    , "NUM_TightID_DEN_TrackerMuons_pt_abseta"               , 1.0, "tightID"  , true, Sys_MuonID_low));
-    MuonISO_module_low     .reset(new MCMuonScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2018/Muon_Iso_SF_RunABCD.root"                   , "NUM_TightRelIso_DEN_TightIDandIPCut_pt_abseta"        , 0.0, "isolation", true, Sys_MuonISO_low));
-    MuonID_module_high     .reset(new MCMuonScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2018/Muon_ID_SF_RunABCD.root"                    , "NUM_TightID_DEN_TrackerMuons_pt_abseta"               , 1.0, "tightID"  , true, Sys_MuonID_high));
-    MuonTrigger_module_low .reset(new MCMuonScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2018/Muon_Trigger_Eff_SF_AfterMuonHLTUpdate.root", "IsoMu24_PtEtaBins/pt_abseta_ratio"                    , 0.5, "Trigger"  , true, Sys_MuonTrigger_low));
-    MuonTrigger_module_high.reset(new MCMuonScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2018/Muon_Trigger_Eff_SF_AfterMuonHLTUpdate.root", "Mu50_OR_OldMu100_OR_TkMu100_PtEtaBins/pt_abseta_ratio", 0.5, "Trigger"  , true, Sys_MuonTrigger_high));
-  }
-
-  if((isUL16preVFP || isUL16postVFP) && isElectron){
-    EleID_module.reset(new MCElecScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2016/egammaEffi.txt_EGM2D_CutBased_Tight_ID.root", 0., "TightID", Sys_EleID));
-    // EleTrigger_module.reset(new MCElecScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2018/SF_2018.root", 0.5, "Trigger", Sys_EleTrigger));
-  }
-  if(isUL17 && isElectron){
-    EleID_module.reset(new MCElecScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2017/2017_ElectronTight.root", 0., "TightID", Sys_EleID));
-    // EleTrigger_module.reset(new MCElecScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2018/SF_2018.root", 0.5, "Trigger", Sys_EleTrigger));
-  }
-  if(isUL18 && isElectron){
-    EleID_module.reset(new MCElecScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2018/2018_ElectronTight.root", 0., "TightID", Sys_EleID));
-    // EleTrigger_module.reset(new MCElecScaleFactor(ctx, "/nfs/dust/cms/user/deleokse/RunII_102X_v2/CMSSW_10_2_17/src/UHH2/common/data/2018/SF_2018.root", 0.5, "Trigger", Sys_EleTrigger));
-  }
+  // dummies (needed to aviod set value errors)
+  sf_muon_iso_low_dummy.reset(new uhh2::MuonIsoScaleFactors(ctx, boost::none, boost::none, boost::none, boost::none, boost::none, true));
+  sf_muon_iso_high_dummy.reset(new uhh2::MuonIsoScaleFactors(ctx, boost::none, boost::none, boost::none, boost::none, boost::none, true));
+  sf_muon_trigger_low_dummy.reset(new uhh2::MuonTriggerScaleFactors(ctx, boost::none, boost::none, boost::none, boost::none, boost::none, true));
+  sf_muon_trigger_high_dummy.reset(new uhh2::MuonTriggerScaleFactors(ctx, boost::none, boost::none, boost::none, boost::none, boost::none, true));
+  sf_ele_id_low_dummy.reset(new uhh2::ElectronIdScaleFactors(ctx, boost::none, boost::none, boost::none, boost::none, true));
+  sf_ele_id_high_dummy.reset(new uhh2::ElectronIdScaleFactors(ctx, boost::none, boost::none, boost::none, boost::none, true));
+  sf_ele_reco_dummy.reset(new uhh2::ElectronRecoScaleFactors(ctx, boost::none, boost::none, boost::none, boost::none, true));
 
 
   // Selection modules
@@ -656,6 +630,8 @@ ZprimeAnalysisModule_applyNN::ZprimeAnalysisModule_applyNN(uhh2::Context& ctx){
   Trigger_mu_B_selection.reset(new TriggerSelection(trigger_mu_B));
   Trigger_mu_C_selection.reset(new TriggerSelection(trigger_mu_C));
   Trigger_mu_D_selection.reset(new TriggerSelection(trigger_mu_D));
+  Trigger_mu_E_selection.reset(new TriggerSelection(trigger_mu_E));
+  Trigger_mu_F_selection.reset(new TriggerSelection(trigger_mu_F));
 
   Trigger_ele_A_selection.reset(new TriggerSelection(trigger_ele_A));
   Trigger_ele_B_selection.reset(new TriggerSelection(trigger_ele_B));
@@ -716,14 +692,10 @@ ZprimeAnalysisModule_applyNN::ZprimeAnalysisModule_applyNN(uhh2::Context& ctx){
   sel_1btag.reset(new NJetSelection(1, -1, id_btag));
   sel_2btag.reset(new NJetSelection(2,-1, id_btag));
 
-  h_musf_iso      = ctx.declare_event_output<float>("weight_sfmu_isolation");
-  h_musf_iso_up   = ctx.declare_event_output<float>("weight_sfmu_isolation_up");
-  h_musf_iso_down = ctx.declare_event_output<float>("weight_sfmu_isolation_down");
-
   TopJetBtagSubjet_selection.reset(new ZprimeBTagFatSubJetSelection(ctx));
 
   // Book histograms
- vector<string> histogram_tags = {"Weights_Init", "Weights_PU", "Weights_Lumi", "Weights_TopPt", "Weights_MCScale", "Weights_TopTag_SF", "Corrections", "IDMuon_SF", "IsoMuon_SF", "Muon1_LowPt", "Muon1_HighPt", "Ele1_LowPt", "Ele1_HighPt", "TriggerMuon_SF", "TriggerMuon", "TriggerEle", "TwoDCut_Muon", "TwoDCut_Ele", "Jet1", "Jet2", "MET", "HTlep","Btags1", "Btags1_SF", "NNInputsBeforeReweight","DNN_output0","DNN_output1","DNN_output2","DNN_output0_TopTag","DNN_output1_TopTag","DNN_output2_TopTag","DNN_output0_NoTopTag","DNN_output1_NoTopTag","DNN_output2_NoTopTag", "DNN_output0_thetastar_bin1", "DNN_output0_thetastar_bin2", "DNN_output0_thetastar_bin3", "DNN_output0_thetastar_bin4", "DNN_output0_TopTag_thetastar_bin1", "DNN_output0_TopTag_thetastar_bin2", "DNN_output0_TopTag_thetastar_bin3", "DNN_output0_TopTag_thetastar_bin4", "DNN_output0_NoTopTag_thetastar_bin1", "DNN_output0_NoTopTag_thetastar_bin2", "DNN_output0_NoTopTag_thetastar_bin3", "DNN_output0_NoTopTag_thetastar_bin4", "DNN_output0_TopTag_chi2_max1", "DNN_output0_NoTopTag_chi2_max1", "DNN_output0_TopTag_chi2_max2", "DNN_output0_NoTopTag_chi2_max2", "DNN_output0_thetastar_bin1_chi2_max1", "DNN_output0_thetastar_bin2_chi2_max1", "DNN_output0_thetastar_bin3_chi2_max1", "DNN_output0_thetastar_bin4_chi2_max1", "DNN_output0_TopTag_thetastar_bin1_chi2_max1", "DNN_output0_TopTag_thetastar_bin2_chi2_max1", "DNN_output0_TopTag_thetastar_bin3_chi2_max1", "DNN_output0_TopTag_thetastar_bin4_chi2_max1", "DNN_output0_NoTopTag_thetastar_bin1_chi2_max1", "DNN_output0_NoTopTag_thetastar_bin2_chi2_max1", "DNN_output0_NoTopTag_thetastar_bin3_chi2_max1", "DNN_output0_NoTopTag_thetastar_bin4_chi2_max1", "DNN_output0_thetastar_bin1_chi2_max2", "DNN_output0_thetastar_bin2_chi2_max2", "DNN_output0_thetastar_bin3_chi2_max2", "DNN_output0_thetastar_bin4_chi2_max2", "DNN_output0_TopTag_thetastar_bin1_chi2_max2", "DNN_output0_TopTag_thetastar_bin2_chi2_max2", "DNN_output0_TopTag_thetastar_bin3_chi2_max2", "DNN_output0_TopTag_thetastar_bin4_chi2_max2", "DNN_output0_NoTopTag_thetastar_bin1_chi2_max2", "DNN_output0_NoTopTag_thetastar_bin2_chi2_max2", "DNN_output0_NoTopTag_thetastar_bin3_chi2_max2", "DNN_output0_NoTopTag_thetastar_bin4_chi2_max2", "DNN_output0_chi2_max1", "DNN_output0_Nochi2_max1", "DNN_output0_NoTopTag_Nochi2_max1", "DNN_output0_TopTag_Nochi2_max1"};
+  vector<string> histogram_tags = {"Weights_Init", "Weights_PU", "Weights_Lumi", "Weights_TopPt", "Weights_MCScale", "Weights_TopTag_SF", "Corrections", "Muon1_LowPt", "Muon1_HighPt", "Ele1_LowPt", "Ele1_HighPt", "IdEle_SF", "IsoMuon_SF", "RecoEle_SF", "TriggerMuon", "TriggerEle", "TriggerMuon_SF", "TwoDCut_Muon", "TwoDCut_Ele", "Jet1", "Jet2", "MET", "HTlep", "Btags1", "Btags1_SF", "NNInputsBeforeReweight", "MatchableBeforeChi2Cut", "NotMatchableBeforeChi2Cut", "CorrectMatchBeforeChi2Cut", "NotCorrectMatchBeforeChi2Cut", "Chi2", "Matchable", "NotMatchable", "CorrectMatch", "NotCorrectMatch", "TopTagReconstruction", "NotTopTagReconstruction", "DNN_output0","DNN_output1","DNN_output2","DNN_output0_TopTag","DNN_output1_TopTag","DNN_output2_TopTag","DNN_output0_NoTopTag","DNN_output1_NoTopTag","DNN_output2_NoTopTag", "DNN_output0_thetastar_bin1", "DNN_output0_thetastar_bin2", "DNN_output0_thetastar_bin3", "DNN_output0_thetastar_bin4", "DNN_output0_TopTag_thetastar_bin1", "DNN_output0_TopTag_thetastar_bin2", "DNN_output0_TopTag_thetastar_bin3", "DNN_output0_TopTag_thetastar_bin4", "DNN_output0_NoTopTag_thetastar_bin1", "DNN_output0_NoTopTag_thetastar_bin2", "DNN_output0_NoTopTag_thetastar_bin3", "DNN_output0_NoTopTag_thetastar_bin4", "DNN_output0_TopTag_chi2_max1", "DNN_output0_NoTopTag_chi2_max1", "DNN_output0_TopTag_chi2_max2", "DNN_output0_NoTopTag_chi2_max2", "DNN_output0_thetastar_bin1_chi2_max1", "DNN_output0_thetastar_bin2_chi2_max1", "DNN_output0_thetastar_bin3_chi2_max1", "DNN_output0_thetastar_bin4_chi2_max1", "DNN_output0_TopTag_thetastar_bin1_chi2_max1", "DNN_output0_TopTag_thetastar_bin2_chi2_max1", "DNN_output0_TopTag_thetastar_bin3_chi2_max1", "DNN_output0_TopTag_thetastar_bin4_chi2_max1", "DNN_output0_NoTopTag_thetastar_bin1_chi2_max1", "DNN_output0_NoTopTag_thetastar_bin2_chi2_max1", "DNN_output0_NoTopTag_thetastar_bin3_chi2_max1", "DNN_output0_NoTopTag_thetastar_bin4_chi2_max1", "DNN_output0_thetastar_bin1_chi2_max2", "DNN_output0_thetastar_bin2_chi2_max2", "DNN_output0_thetastar_bin3_chi2_max2", "DNN_output0_thetastar_bin4_chi2_max2", "DNN_output0_TopTag_thetastar_bin1_chi2_max2", "DNN_output0_TopTag_thetastar_bin2_chi2_max2", "DNN_output0_TopTag_thetastar_bin3_chi2_max2", "DNN_output0_TopTag_thetastar_bin4_chi2_max2", "DNN_output0_NoTopTag_thetastar_bin1_chi2_max2", "DNN_output0_NoTopTag_thetastar_bin2_chi2_max2", "DNN_output0_NoTopTag_thetastar_bin3_chi2_max2", "DNN_output0_NoTopTag_thetastar_bin4_chi2_max2", "DNN_output0_chi2_max1", "DNN_output0_Nochi2_max1", "DNN_output0_NoTopTag_Nochi2_max1", "DNN_output0_TopTag_Nochi2_max1"};
   book_histograms(ctx, histogram_tags);
 
   h_MulticlassNN_output.reset(new ZprimeSemiLeptonicMulticlassNNHists(ctx, "MulticlassNN"));
@@ -880,31 +852,34 @@ bool ZprimeAnalysisModule_applyNN::process(uhh2::Event& event){
 
   // Run top-tagging
   if(ishotvr){
-  TopTaggerHOTVR->process(event);
-  hadronic_top->process(event);
+    TopTaggerHOTVR->process(event);
+    hadronic_top->process(event);
   }else if(isdeepAK8){
-  TopTaggerDeepAK8->process(event);
+    TopTaggerDeepAK8->process(event);
   }
   if(debug) cout<<"Top Tagger ok"<<endl;
 
   fill_histograms(event, "Weights_Init");
   lumihists_Weights_Init->fill(event);
 
-  // Weight modules
+  // pileup weight
   PUWeight_module->process(event);
   if(debug)  cout<<"PUWeight ok"<<endl;
   fill_histograms(event, "Weights_PU");
   lumihists_Weights_PU->fill(event);
 
+  // lumi weight
   LumiWeight_module->process(event);
   if(debug)  cout<<"LumiWeight ok"<<endl;
   fill_histograms(event, "Weights_Lumi");
   lumihists_Weights_Lumi->fill(event);
 
+  // top pt reweighting
   TopPtReweight_module->process(event);
   fill_histograms(event, "Weights_TopPt");
   lumihists_Weights_TopPt->fill(event);
 
+  // MC scale
   MCScale_module->process(event);
   fill_histograms(event, "Weights_MCScale");
   lumihists_Weights_MCScale->fill(event);
@@ -956,139 +931,151 @@ bool ZprimeAnalysisModule_applyNN::process(uhh2::Event& event){
     if( !(ele_is_high || ele_is_low) ) return false;
   }
 
-  // Lepton ID SF
+
+  // apply lepton id scale factors: electrons only (isolation included in ids)
   if(isMuon){
-    // low pt
-    if(muon_is_low){
-      MuonID_module_low->process(event);
-    }
-    // high pt
-    if(muon_is_high){
-      MuonID_module_high->process(event);
-    }
-    fill_histograms(event, "IDMuon_SF");
+    sf_ele_id_low_dummy->process(event);
+    sf_ele_id_high_dummy->process(event);
   }
   if(isElectron){
-    EleID_module->process(event);
-    if(debug)  cout<<"EleID ok"<<endl;
+    if(ele_is_low){
+      sf_ele_id_low->process(event);
+      sf_ele_id_high_dummy->process(event);
+    }
+    else if(ele_is_high){
+      sf_ele_id_low_dummy->process(event);
+      sf_ele_id_high->process(event);
+    }
+    fill_histograms(event, "IdEle_SF");
   }
 
-
-  // Muon ISO SF
-  if(isMuon){  // high pt
-    event.set(h_musf_iso, 1.);
-    event.set(h_musf_iso_up, 1.);
-    event.set(h_musf_iso_down, 1.);
-    if(muon_is_low){ // low pt
-      MuonISO_module_low->process(event);
+  // apply lepton isolation scale factors: muons only (include both id and isolation)
+  if(isMuon){
+    if(muon_is_low){
+      sf_muon_iso_low->process(event);
+      sf_muon_iso_high_dummy->process(event);
+    }
+    else if(muon_is_high){
+      sf_muon_iso_low_dummy->process(event);
+      sf_muon_iso_high->process(event);
     }
     fill_histograms(event, "IsoMuon_SF");
   }
-  // dummy for ele channel
   if(isElectron){
-    event.set(h_musf_iso, 1.);
-    event.set(h_musf_iso_up, 1.);
-    event.set(h_musf_iso_down, 1.);
+    sf_muon_iso_high_dummy->process(event);
+    sf_muon_iso_low_dummy->process(event);
+  }
+
+  // apply lepton reco scale factors: electrons only
+  if(isMuon){
+    sf_ele_reco_dummy->process(event);
+  }
+  if(isElectron){
+    sf_ele_reco->process(event);
+    fill_histograms(event, "RecoEle_SF");
   }
 
 
-  //  // Trigger MUON channel
-  //  if(isMuon){
-  //     // low pt
-  //     if(muon_is_low){
-  //        if(is2016v2 || is2016v3){
-  //         if(!(Trigger_mu_A_selection->passes(event) || Trigger_mu_B_selection->passes(event))) return false;
-  //        }
-  //        else{
-  //         if(!Trigger_mu_A_selection->passes(event)) return false;
-  //        }
-  //     }
-  //     // high pt
-  //     if(muon_is_high){
-  //        if(is2016v2 || is2016v3){ // 2016
-  //           // DATA below runnumb
-  //           if(!isMC && event.run < 274954){
-  //            if(!Trigger_mu_C_selection->passes(event)) return false;
-  //           }
-  //           // DATA above runnumb & MC
-  //           else{
-  //            if(!(Trigger_mu_C_selection->passes(event) || Trigger_mu_D_selection->passes(event))) return false;
-  //           }
-  //        } // 2017 & 2018
-  //        else{
-  //         if(!Trigger_mu_C_selection->passes(event)) return false;
-  //        }
-  //
-  //     }
-  //  fill_histograms(event, "TriggerMuon");
-  //  lumihists_TriggerMuon->fill(event);
-  //  }
-  //
-  //  // Trigger ELECTRON channel
-  //  if(isElectron){
-  //     // low pt
-  //     if(ele_is_low){
-  //         if(!Trigger_ele_A_selection->passes(event)) return false;
-  //     }
-  //     // high pt
-  //     if(ele_is_high){
-  //        // MC
-  //        if(isMC){
-  //          if(!(Trigger_ele_B_selection->passes(event) || Trigger_ph_A_selection->passes(event))) return false;
-  //        }else{
-  //        //DATA
-  //            // 2016
-  //            if(is2016v2 || is2016v3){
-  //                if(isPhoton){ // photon stream
-  //                    if(Trigger_ele_B_selection->passes(event) && !Trigger_ph_A_selection->passes(event)) return false;
-  //                }else{ // electron stream
-  //                   if(!Trigger_ele_B_selection->passes(event)) return false;
-  //                }
-  //            }
-  //            // 2017
-  //            if(is2017v2){
-  //              // below runnumb trigger Ele115 does not exist
-  //              if(event.run < 299329){
-  //                if(isPhoton){ // photon stream
-  //                    if(Trigger_ele_A_selection->passes(event) && !Trigger_ph_A_selection->passes(event)) return false;
-  //                }else{ // electron stream
-  //                   if(!Trigger_ele_A_selection->passes(event)) return false;
-  //                }
-  //              }else{ // above runnumb with Ele115
-  //                if(isPhoton){ // photon stream
-  //                    if(Trigger_ele_B_selection->passes(event) && !Trigger_ph_A_selection->passes(event)) return false;
-  //                }else{ // electron stream
-  //                   if(!Trigger_ele_B_selection->passes(event)) return false;
-  //                }
-  //              }
-  //            }
-  //            // 2018 photon & electron together: EGamma DATA
-  //            if(is2018){
-  //               if(!(Trigger_ele_B_selection->passes(event)|| Trigger_ph_A_selection->passes(event))) return false;
-  //            }
-  //
-  //        }
-  //     }
-  //  fill_histograms(event, "TriggerEle");
-  //  lumihists_TriggerEle->fill(event);
-  //  }
-  //
-  //
 
-  // Lepton Trigger SF
+  // Trigger MUON channel
+  if(isMuon){
+    // low pt
+    if(muon_is_low){
+      if(isUL16preVFP || isUL16postVFP){
+        if(!(Trigger_mu_A_selection->passes(event) || Trigger_mu_B_selection->passes(event))) return false;
+      }
+      else{
+        if(!Trigger_mu_A_selection->passes(event)) return false;
+      }
+    }
+    // high pt
+    if(muon_is_high){
+      if(isUL16preVFP || isUL16postVFP){ // 2016
+        // DATA below runnumb
+        if(!isMC && event.run < 274954){
+          if(!Trigger_mu_C_selection->passes(event)) return false;
+        }
+        // DATA above runnumb & MC
+        else{
+          if(!(Trigger_mu_C_selection->passes(event) || Trigger_mu_D_selection->passes(event))) return false;
+        }
+      } // 2017 & 2018
+      else{
+        if(!(Trigger_mu_C_selection->passes(event) || Trigger_mu_E_selection->passes(event) || Trigger_mu_F_selection->passes(event))) return false;
+      }
+    }
+    fill_histograms(event, "TriggerMuon");
+    lumihists_TriggerMuon->fill(event);
+  }
+
+  // Trigger ELECTRON channel
+  if(isElectron){
+    // low pt
+    if(ele_is_low){
+      if(!Trigger_ele_A_selection->passes(event)) return false;
+    }
+    // high pt
+    if(ele_is_high){
+      // MC
+      if(isMC){
+        if(!(Trigger_ele_B_selection->passes(event) || Trigger_ph_A_selection->passes(event))) return false;
+      }else{
+        //DATA
+        // 2016
+        if(isUL16preVFP || isUL16postVFP){
+          if(isPhoton){ // photon stream
+            if(Trigger_ele_B_selection->passes(event) && !Trigger_ph_A_selection->passes(event)) return false;
+          }else{ // electron stream
+            if(!Trigger_ele_B_selection->passes(event)) return false;
+          }
+        }
+        // 2017
+        if(isUL17){
+          // below runnumb trigger Ele115 does not exist
+          if(event.run <= 299329){
+            if(isPhoton){ // photon stream
+              if(Trigger_ele_A_selection->passes(event) && !Trigger_ph_A_selection->passes(event)) return false;
+            }else{ // electron stream
+              if(!Trigger_ele_A_selection->passes(event)) return false;
+            }
+          }else{ // above runnumb with Ele115
+            if(isPhoton){ // photon stream
+              if(Trigger_ele_B_selection->passes(event) && !Trigger_ph_A_selection->passes(event)) return false;
+            }else{ // electron stream
+              if(!Trigger_ele_B_selection->passes(event)) return false;
+            }
+          }
+        }
+        // 2018 photon & electron together: EGamma DATA
+        if(isUL18){
+          if(!(Trigger_ele_B_selection->passes(event)|| Trigger_ph_A_selection->passes(event))) return false;
+        }
+
+      }
+    }
+    fill_histograms(event, "TriggerEle");
+    lumihists_TriggerEle->fill(event);
+  }
+
+
+  // apply lepton trigger scale factors
   if(isMuon){
     if(muon_is_low){
-      MuonTrigger_module_low->process_onemuon(event, 0);
+      sf_muon_trigger_low->process(event);
+      sf_muon_trigger_high_dummy->process(event);
     }
     if(muon_is_high){
-      MuonTrigger_module_high->process_onemuon(event, 0);
+      sf_muon_trigger_low_dummy->process(event);
+      sf_muon_trigger_high->process(event);
     }
     fill_histograms(event, "TriggerMuon_SF");
   }
-  //if(isElectron){
-  //  EleTrigger_module->process(event);
-  //  fill_histograms(event, "TriggerEle");
-  //}
+  if(isElectron){
+    // TODO: implement electron trigger SFs (low + high pt)
+    // fill_histograms(event, "TriggerEle");
+    sf_muon_trigger_low_dummy->process(event);
+    sf_muon_trigger_high_dummy->process(event);
+  }
 
 
   ////btag shape sf (Ak4 chs jets)
@@ -1096,14 +1083,14 @@ bool ZprimeAnalysisModule_applyNN::process(uhh2::Event& event){
   //fill_histograms(event, "Btags1_SF");
 
   CandidateBuilder->process(event);
-  if(debug) cout<<"CandidateBuilder is ok"<<endl;
+  if(debug) cout << "CandidateBuilder: ok" << endl;
   Chi2DiscriminatorZprime->process(event);
-  if(debug)  cout<<"Chi2DiscriminatorZprime is ok"<<endl;
+  if(debug) cout << "Chi2DiscriminatorZprime: ok" << endl;
   CorrectMatchDiscriminatorZprime->process(event);
-  if(debug) cout<<"CorrectMatchDiscriminatorZprime is ok"<<endl;
-  if(sample.Contains("_blinded")){
-    if(!BlindData_selection->passes(event)) return false;
-  }
+  if(debug) cout << "CorrectMatchDiscriminatorZprime: ok" << endl;
+  // if(sample.Contains("_blinded")){
+  //   if(!BlindData_selection->passes(event)) return false;
+  // }
 
   // Variables for NN
   Variables_module->process(event);
@@ -1132,7 +1119,7 @@ bool ZprimeAnalysisModule_applyNN::process(uhh2::Event& event){
     }
   }
 
-// out0=TTbar, out1=ST, out2=WJets
+  // out0=TTbar, out1=ST, out2=WJets
   if( out0 == max_score ){
     fill_histograms(event, "DNN_output0");
     if( ZprimeTopTag_selection->passes(event) ) fill_histograms(event, "DNN_output0_TopTag");
@@ -1151,115 +1138,115 @@ bool ZprimeAnalysisModule_applyNN::process(uhh2::Event& event){
     else fill_histograms(event, "DNN_output2_NoTopTag");
   }
 
-//Define categories on theta star to reduce ttbar background
+  //Define categories on theta star to reduce ttbar background
   if( out0 == max_score ){
-     if(ThetaStar_selection_bin1->passes(event)){
-         fill_histograms(event, "DNN_output0_thetastar_bin1");
-     }else if(ThetaStar_selection_bin2->passes(event)){
-         fill_histograms(event, "DNN_output0_thetastar_bin2");
-     }else if(ThetaStar_selection_bin3->passes(event)){
-         fill_histograms(event, "DNN_output0_thetastar_bin3");
-     }else{
-         fill_histograms(event, "DNN_output0_thetastar_bin4");
-     }
-     if( ZprimeTopTag_selection->passes(event) ){
-         if(ThetaStar_selection_bin1->passes(event)){
-             fill_histograms(event, "DNN_output0_TopTag_thetastar_bin1");
-         }else if(ThetaStar_selection_bin2->passes(event)){
-             fill_histograms(event, "DNN_output0_TopTag_thetastar_bin2");
-         }else if(ThetaStar_selection_bin3->passes(event)){
-             fill_histograms(event, "DNN_output0_TopTag_thetastar_bin3");
-         }else{
-             fill_histograms(event, "DNN_output0_TopTag_thetastar_bin4");
-         }
-     }else{
-         if(ThetaStar_selection_bin1->passes(event)){
-             fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin1");
-         }else if(ThetaStar_selection_bin2->passes(event)){
-             fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin2");
-         }else if(ThetaStar_selection_bin3->passes(event)){
-             fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin3");
-         }else{
-             fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin4");
-         }
-     }
+    if(ThetaStar_selection_bin1->passes(event)){
+      fill_histograms(event, "DNN_output0_thetastar_bin1");
+    }else if(ThetaStar_selection_bin2->passes(event)){
+      fill_histograms(event, "DNN_output0_thetastar_bin2");
+    }else if(ThetaStar_selection_bin3->passes(event)){
+      fill_histograms(event, "DNN_output0_thetastar_bin3");
+    }else{
+      fill_histograms(event, "DNN_output0_thetastar_bin4");
+    }
+    if( ZprimeTopTag_selection->passes(event) ){
+      if(ThetaStar_selection_bin1->passes(event)){
+        fill_histograms(event, "DNN_output0_TopTag_thetastar_bin1");
+      }else if(ThetaStar_selection_bin2->passes(event)){
+        fill_histograms(event, "DNN_output0_TopTag_thetastar_bin2");
+      }else if(ThetaStar_selection_bin3->passes(event)){
+        fill_histograms(event, "DNN_output0_TopTag_thetastar_bin3");
+      }else{
+        fill_histograms(event, "DNN_output0_TopTag_thetastar_bin4");
+      }
+    }else{
+      if(ThetaStar_selection_bin1->passes(event)){
+        fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin1");
+      }else if(ThetaStar_selection_bin2->passes(event)){
+        fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin2");
+      }else if(ThetaStar_selection_bin3->passes(event)){
+        fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin3");
+      }else{
+        fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin4");
+      }
+    }
 
-     if(Chi2_selection1->passes(event)){
-         fill_histograms(event, "DNN_output0_chi2_max1");
-         if(ThetaStar_selection_bin1->passes(event)){
-             fill_histograms(event, "DNN_output0_thetastar_bin1_chi2_max1");
-         }else if(ThetaStar_selection_bin2->passes(event)){
-             fill_histograms(event, "DNN_output0_thetastar_bin2_chi2_max1");
-         }else if(ThetaStar_selection_bin3->passes(event)){
-             fill_histograms(event, "DNN_output0_thetastar_bin3_chi2_max1");
-         }else{
-             fill_histograms(event, "DNN_output0_thetastar_bin4_chi2_max1");
-         }
-         if( ZprimeTopTag_selection->passes(event) ){
-             fill_histograms(event, "DNN_output0_TopTag_chi2_max1");
-             if(ThetaStar_selection_bin1->passes(event)){
-                 fill_histograms(event, "DNN_output0_TopTag_thetastar_bin1_chi2_max1");
-             }else if(ThetaStar_selection_bin2->passes(event)){
-                 fill_histograms(event, "DNN_output0_TopTag_thetastar_bin2_chi2_max1");
-             }else if(ThetaStar_selection_bin3->passes(event)){
-                 fill_histograms(event, "DNN_output0_TopTag_thetastar_bin3_chi2_max1");
-             }else{
-                 fill_histograms(event, "DNN_output0_TopTag_thetastar_bin4_chi2_max1");
-             }
-         }else{
-             fill_histograms(event, "DNN_output0_NoTopTag_chi2_max1");
-             if(ThetaStar_selection_bin1->passes(event)){
-                 fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin1_chi2_max1");
-             }else if(ThetaStar_selection_bin2->passes(event)){
-                 fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin2_chi2_max1");
-             }else if(ThetaStar_selection_bin3->passes(event)){
-                 fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin3_chi2_max1");
-             }else{
-                 fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin4_chi2_max1");
-             }
-         }
-     }else{
-        fill_histograms(event, "DNN_output0_Nochi2_max1");
-        if( ZprimeTopTag_selection->passes(event) ){
-           fill_histograms(event, "DNN_output0_TopTag_Nochi2_max1");
+    if(Chi2_selection1->passes(event)){
+      fill_histograms(event, "DNN_output0_chi2_max1");
+      if(ThetaStar_selection_bin1->passes(event)){
+        fill_histograms(event, "DNN_output0_thetastar_bin1_chi2_max1");
+      }else if(ThetaStar_selection_bin2->passes(event)){
+        fill_histograms(event, "DNN_output0_thetastar_bin2_chi2_max1");
+      }else if(ThetaStar_selection_bin3->passes(event)){
+        fill_histograms(event, "DNN_output0_thetastar_bin3_chi2_max1");
+      }else{
+        fill_histograms(event, "DNN_output0_thetastar_bin4_chi2_max1");
+      }
+      if( ZprimeTopTag_selection->passes(event) ){
+        fill_histograms(event, "DNN_output0_TopTag_chi2_max1");
+        if(ThetaStar_selection_bin1->passes(event)){
+          fill_histograms(event, "DNN_output0_TopTag_thetastar_bin1_chi2_max1");
+        }else if(ThetaStar_selection_bin2->passes(event)){
+          fill_histograms(event, "DNN_output0_TopTag_thetastar_bin2_chi2_max1");
+        }else if(ThetaStar_selection_bin3->passes(event)){
+          fill_histograms(event, "DNN_output0_TopTag_thetastar_bin3_chi2_max1");
         }else{
-           fill_histograms(event, "DNN_output0_NoTopTag_Nochi2_max1");
+          fill_histograms(event, "DNN_output0_TopTag_thetastar_bin4_chi2_max1");
         }
-     }
-     if(Chi2_selection2->passes(event)){
-         if(ThetaStar_selection_bin1->passes(event)){
-             fill_histograms(event, "DNN_output0_thetastar_bin1_chi2_max2");
-         }else if(ThetaStar_selection_bin2->passes(event)){
-             fill_histograms(event, "DNN_output0_thetastar_bin2_chi2_max2");
-         }else if(ThetaStar_selection_bin3->passes(event)){
-             fill_histograms(event, "DNN_output0_thetastar_bin3_chi2_max2");
-         }else{
-             fill_histograms(event, "DNN_output0_thetastar_bin4_chi2_max2");
-         }
-         if( ZprimeTopTag_selection->passes(event) ){
-             fill_histograms(event, "DNN_output0_TopTag_chi2_max2");
-             if(ThetaStar_selection_bin1->passes(event)){
-                 fill_histograms(event, "DNN_output0_TopTag_thetastar_bin1_chi2_max2");
-             }else if(ThetaStar_selection_bin2->passes(event)){
-                 fill_histograms(event, "DNN_output0_TopTag_thetastar_bin2_chi2_max2");
-             }else if(ThetaStar_selection_bin3->passes(event)){
-                 fill_histograms(event, "DNN_output0_TopTag_thetastar_bin3_chi2_max2");
-             }else{
-                 fill_histograms(event, "DNN_output0_TopTag_thetastar_bin4_chi2_max2");
-             }
-         }else{
-             fill_histograms(event, "DNN_output0_NoTopTag_chi2_max2");
-             if(ThetaStar_selection_bin1->passes(event)){
-                 fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin1_chi2_max2");
-             }else if(ThetaStar_selection_bin2->passes(event)){
-                 fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin2_chi2_max2");
-             }else if(ThetaStar_selection_bin3->passes(event)){
-                 fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin3_chi2_max2");
-             }else{
-                 fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin4_chi2_max2");
-             }
-         }
-     }
+      }else{
+        fill_histograms(event, "DNN_output0_NoTopTag_chi2_max1");
+        if(ThetaStar_selection_bin1->passes(event)){
+          fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin1_chi2_max1");
+        }else if(ThetaStar_selection_bin2->passes(event)){
+          fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin2_chi2_max1");
+        }else if(ThetaStar_selection_bin3->passes(event)){
+          fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin3_chi2_max1");
+        }else{
+          fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin4_chi2_max1");
+        }
+      }
+    }else{
+      fill_histograms(event, "DNN_output0_Nochi2_max1");
+      if( ZprimeTopTag_selection->passes(event) ){
+        fill_histograms(event, "DNN_output0_TopTag_Nochi2_max1");
+      }else{
+        fill_histograms(event, "DNN_output0_NoTopTag_Nochi2_max1");
+      }
+    }
+    if(Chi2_selection2->passes(event)){
+      if(ThetaStar_selection_bin1->passes(event)){
+        fill_histograms(event, "DNN_output0_thetastar_bin1_chi2_max2");
+      }else if(ThetaStar_selection_bin2->passes(event)){
+        fill_histograms(event, "DNN_output0_thetastar_bin2_chi2_max2");
+      }else if(ThetaStar_selection_bin3->passes(event)){
+        fill_histograms(event, "DNN_output0_thetastar_bin3_chi2_max2");
+      }else{
+        fill_histograms(event, "DNN_output0_thetastar_bin4_chi2_max2");
+      }
+      if( ZprimeTopTag_selection->passes(event) ){
+        fill_histograms(event, "DNN_output0_TopTag_chi2_max2");
+        if(ThetaStar_selection_bin1->passes(event)){
+          fill_histograms(event, "DNN_output0_TopTag_thetastar_bin1_chi2_max2");
+        }else if(ThetaStar_selection_bin2->passes(event)){
+          fill_histograms(event, "DNN_output0_TopTag_thetastar_bin2_chi2_max2");
+        }else if(ThetaStar_selection_bin3->passes(event)){
+          fill_histograms(event, "DNN_output0_TopTag_thetastar_bin3_chi2_max2");
+        }else{
+          fill_histograms(event, "DNN_output0_TopTag_thetastar_bin4_chi2_max2");
+        }
+      }else{
+        fill_histograms(event, "DNN_output0_NoTopTag_chi2_max2");
+        if(ThetaStar_selection_bin1->passes(event)){
+          fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin1_chi2_max2");
+        }else if(ThetaStar_selection_bin2->passes(event)){
+          fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin2_chi2_max2");
+        }else if(ThetaStar_selection_bin3->passes(event)){
+          fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin3_chi2_max2");
+        }else{
+          fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin4_chi2_max2");
+        }
+      }
+    }
 
   }//end out0
 

--- a/src/ZprimePreselectionModule.cxx
+++ b/src/ZprimePreselectionModule.cxx
@@ -114,7 +114,7 @@ ZprimePreselectionModule::ZprimePreselectionModule(uhh2::Context& ctx){
   ElectronId eleID_low  = ElectronTagID(Electron::mvaEleID_Fall17_iso_V2_wp80);
   MuonId     muID_low   = AndId<Muon>(MuonID(Muon::CutBasedIdTight), MuonID(Muon::PFIsoTight));
   ElectronId eleID_high = ElectronTagID(Electron::mvaEleID_Fall17_noIso_V2_wp80);
-  MuonId     muID_high  = MuonID(Muon::CutBasedIdGlobalHighPt);
+  MuonId     muID_high  = AndId<Muon>(MuonID(Muon::CutBasedIdGlobalHighPt), MuonID(Muon::TkIsoLoose));
 
   double electron_pt_low(35.);
   double muon_pt_low(30.);


### PR DESCRIPTION
This PR updates the following lepton properties and includes their scale factors using the new ```LeptonScaleFactors```class (see [PR#1625](https://github.com/UHH2/UHH2/pull/1625)).

Muon low pT:
- id + iso: changed from ```CutBasedIdTight + I_rel < 0.15``` to ```CutBasedIdTight + PFIsoTight```
- SFs: id, iso, trigger updated

Muon high pT:
- id + iso: changed from ```CutBasedIdGlobalHighPt ``` to ```CutBasedIdGlobalHighPt + TkIsoLoose```
- trigger (UL17,18): changed from ```HLT_Mu50``` to ```HLT_Mu50 || HLT_OldMu100 || HLT_TkMu100```
- SFs: id, iso, trigger updated

Electron (low & high pT):
- SFs: id updated, reco added

Useful twikis: [MuonUL16](https://twiki.cern.ch/twiki/bin/view/CMS/MuonUL2016), [MuonUL17](https://twiki.cern.ch/twiki/bin/view/CMS/MuonUL2017), [MuonUL18](https://twiki.cern.ch/twiki/bin/viewauth/CMS/MuonUL2018), [EGammaUL16to18](https://twiki.cern.ch/twiki/bin/view/CMS/EgammaUL2016To2018)
