### PR TITLE
save Mtt histograms with systematic variations

### DIFF
--- a/include/ZprimeSemiLeptonicHists.h
+++ b/include/ZprimeSemiLeptonicHists.h
@@ -72,6 +72,8 @@ protected:
 
   TH1F *hadtop_thetastar, *cos_hadtop_thetastar, *leptop_thetastar, *cos_leptop_thetastar;
 
+  TH2F *N_Jets_vs_HT;
+
   uhh2::Event::Handle< std::vector<TopJet> > h_AK8TopTags;
   uhh2::Event::Handle<bool> h_is_zprime_reconstructed_chi2;
   uhh2::Event::Handle<bool> h_is_zprime_reconstructed_correctmatch;

--- a/include/ZprimeSemiLeptonicSystematicsHists.h
+++ b/include/ZprimeSemiLeptonicSystematicsHists.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "UHH2/core/include/Hists.h"
+#include "UHH2/core/include/Event.h"
+#include "UHH2/ZprimeSemiLeptonic/include/ZprimeSemiLeptonicModules.h"
+
+#include <UHH2/common/include/TTbarGen.h>
+#include <UHH2/common/include/TTbarReconstruction.h>
+#include <UHH2/common/include/ReconstructionHypothesisDiscriminators.h>
+
+#include <TLorentzVector.h>
+#include <string>
+
+class ZprimeSemiLeptonicSystematicsHists: public uhh2::Hists {
+public:
+  explicit ZprimeSemiLeptonicSystematicsHists(uhh2::Context&, const std::string&);
+  virtual void fill(const uhh2::Event&) override;
+
+protected:
+  void init();
+  bool is_mc, is_Muon;
+
+  uhh2::Event::Handle<float> h_ele_reco;        
+  uhh2::Event::Handle<float> h_ele_reco_up;    
+  uhh2::Event::Handle<float> h_ele_reco_down; 
+  uhh2::Event::Handle<float> h_ele_id;          
+  uhh2::Event::Handle<float> h_ele_id_up;       
+  uhh2::Event::Handle<float> h_ele_id_down;  
+  uhh2::Event::Handle<float> h_mu_reco;         
+  uhh2::Event::Handle<float> h_mu_reco_up;      
+  uhh2::Event::Handle<float> h_mu_reco_down;    
+  uhh2::Event::Handle<float> h_mu_iso;          
+  uhh2::Event::Handle<float> h_mu_iso_up;       
+  uhh2::Event::Handle<float> h_mu_iso_down;
+  uhh2::Event::Handle<float> h_mu_id;           
+  uhh2::Event::Handle<float> h_mu_id_up;        
+  uhh2::Event::Handle<float> h_mu_id_down;      
+  uhh2::Event::Handle<float> h_mu_trigger;      
+  uhh2::Event::Handle<float> h_mu_trigger_up;   
+  uhh2::Event::Handle<float> h_mu_trigger_down; 
+  uhh2::Event::Handle<float> h_pu;              
+  uhh2::Event::Handle<float> h_pu_up;           
+  uhh2::Event::Handle<float> h_pu_down;         
+  uhh2::Event::Handle<float> h_prefiring;       
+  uhh2::Event::Handle<float> h_prefiring_up;    
+  uhh2::Event::Handle<float> h_prefiring_down;  
+  uhh2::Event::Handle<float> h_toppt;           
+  uhh2::Event::Handle<float> h_toppt_a_up;      
+  uhh2::Event::Handle<float> h_toppt_a_down;    
+  uhh2::Event::Handle<float> h_toppt_b_up;      
+  uhh2::Event::Handle<float> h_toppt_b_down;    
+  uhh2::Event::Handle<float> h_murmuf_upup;
+  uhh2::Event::Handle<float> h_murmuf_upnone;
+  uhh2::Event::Handle<float> h_murmuf_noneup;
+  uhh2::Event::Handle<float> h_murmuf_nonedown;
+  uhh2::Event::Handle<float> h_murmuf_downnone;
+  uhh2::Event::Handle<float> h_murmuf_downdown;
+
+  TH1F *M_Zprime;
+  TH1F *M_Zprime_mu_reco_up;
+  TH1F *M_Zprime_mu_reco_down;
+  TH1F *M_Zprime_pu_up;
+  TH1F *M_Zprime_pu_down;
+  TH1F *M_Zprime_prefiring_up;
+  TH1F *M_Zprime_prefiring_down;
+  TH1F *M_Zprime_mu_id_up;
+  TH1F *M_Zprime_mu_id_down;
+  TH1F *M_Zprime_mu_iso_up;
+  TH1F *M_Zprime_mu_iso_down;
+  TH1F *M_Zprime_mu_trigger_up;
+  TH1F *M_Zprime_mu_trigger_down;
+  TH1F *M_Zprime_ele_id_up;
+  TH1F *M_Zprime_ele_id_down;
+  TH1F *M_Zprime_ele_reco_up;
+  TH1F *M_Zprime_ele_reco_down;
+  TH1F *M_Zprime_toppt_a_up;
+  TH1F *M_Zprime_toppt_a_down;
+  TH1F *M_Zprime_toppt_b_up;
+  TH1F *M_Zprime_toppt_b_down;
+  TH1F *M_Zprime_murmuf_upup;
+  TH1F *M_Zprime_murmuf_upnone;
+  TH1F *M_Zprime_murmuf_noneup;
+  TH1F *M_Zprime_murmuf_nonedown;
+  TH1F *M_Zprime_murmuf_downnone;
+  TH1F *M_Zprime_murmuf_downdown;
+
+
+  uhh2::Event::Handle<bool> h_is_zprime_reconstructed_chi2;
+  uhh2::Event::Handle<ZprimeCandidate*> h_BestZprimeCandidateChi2;
+  uhh2::Event::Handle<std::vector<ReconstructionHypothesis>> h_ttbar_hyps;
+  virtual ~ZprimeSemiLeptonicSystematicsHists();
+};

--- a/src/ZprimeAnalysisModule_applyNN.cxx
+++ b/src/ZprimeAnalysisModule_applyNN.cxx
@@ -35,6 +35,7 @@
 #include <UHH2/ZprimeSemiLeptonic/include/ZprimeSemiLeptonicModules.h>
 #include <UHH2/ZprimeSemiLeptonic/include/TTbarLJHists.h>
 #include <UHH2/ZprimeSemiLeptonic/include/ZprimeSemiLeptonicHists.h>
+#include <UHH2/ZprimeSemiLeptonic/include/ZprimeSemiLeptonicSystematicsHists.h>
 #include <UHH2/ZprimeSemiLeptonic/include/ZprimeSemiLeptonicMulticlassNNHists.h>
 #include <UHH2/ZprimeSemiLeptonic/include/ZprimeSemiLeptonicGeneratorHists.h>
 #include <UHH2/ZprimeSemiLeptonic/include/ZprimeSemiLeptonicCHSMatchHists.h>
@@ -257,8 +258,8 @@ void NeuralNetworkModule::CreateInputs(Event & event){
   double mean_val[65];
   double std_val[65];
   //Only Ele or Mu variables!!
-  ifstream normfile ("/nfs/dust/cms/user/deleokse/RunII_106_v2/CMSSW_10_6_28/src/UHH2/ZprimeSemiLeptonic/KerasNN/NN_DeepAK8_UL18_muon/NormInfo.txt", ios::in);
-  //ifstream normfile ("/nfs/dust/cms/user/deleokse/RunII_106_v2/CMSSW_10_6_28/src/UHH2/ZprimeSemiLeptonic/KerasNN/NN_DeepAK8_UL18_ele/NormInfo.txt", ios::in);
+  //ifstream normfile ("/nfs/dust/cms/user/deleokse/RunII_106_v2/CMSSW_10_6_28/src/UHH2/ZprimeSemiLeptonic/KerasNN/NN_DeepAK8_UL18_muon/NormInfo.txt", ios::in);
+  ifstream normfile ("/nfs/dust/cms/user/deleokse/RunII_106_v2/CMSSW_10_6_28/src/UHH2/ZprimeSemiLeptonic/KerasNN/NN_DeepAK8_UL18_ele/NormInfo.txt", ios::in);
   if(!normfile.good()) throw runtime_error("NeuralNetworkModule: The specified norm file does not exist.");
   if (normfile.is_open()){
     for(int i = 0; i < 65; ++i)
@@ -356,6 +357,31 @@ protected:
 
   // DNN multiclass output hist
   std::unique_ptr<Hists> h_MulticlassNN_output;
+
+  // Hists with systematics variations
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output0;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output1;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output2;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output0_TopTag;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output1_TopTag;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output2_TopTag;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output0_NoTopTag;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output1_NoTopTag;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output2_NoTopTag;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output0_thetastar_bin1;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output0_thetastar_bin2;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output0_thetastar_bin3;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output0_thetastar_bin4;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output0_TopTag_thetastar_bin1;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output0_TopTag_thetastar_bin2;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output0_TopTag_thetastar_bin3;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output0_TopTag_thetastar_bin4;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output0_NoTopTag_thetastar_bin1;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output0_NoTopTag_thetastar_bin2;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output0_NoTopTag_thetastar_bin3;
+  std::unique_ptr<Hists> h_Zprime_SystVariations_DNN_output0_NoTopTag_thetastar_bin4;
+
+
 
   // Configuration
   bool isMC, ishotvr, isdeepAK8;
@@ -658,8 +684,31 @@ ZprimeAnalysisModule_applyNN::ZprimeAnalysisModule_applyNN(uhh2::Context& ctx){
   sel_1btag.reset(new NJetSelection(1, -1, id_btag));
   sel_2btag.reset(new NJetSelection(2,-1, id_btag));
 
+  // Hist with Syst Variations
+  h_Zprime_SystVariations_DNN_output0.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output0"));
+  h_Zprime_SystVariations_DNN_output1.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output1"));
+  h_Zprime_SystVariations_DNN_output2.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output2"));
+  h_Zprime_SystVariations_DNN_output0_TopTag.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output0_TopTag"));
+  h_Zprime_SystVariations_DNN_output1_TopTag.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output1_TopTag"));
+  h_Zprime_SystVariations_DNN_output2_TopTag.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output2_TopTag"));
+  h_Zprime_SystVariations_DNN_output0_NoTopTag.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output0_NoTopTag"));
+  h_Zprime_SystVariations_DNN_output1_NoTopTag.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output1_NoTopTag"));
+  h_Zprime_SystVariations_DNN_output2_NoTopTag.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output2_NoTopTag"));
+  h_Zprime_SystVariations_DNN_output0_thetastar_bin1.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output0_thetastar_bin1"));
+  h_Zprime_SystVariations_DNN_output0_thetastar_bin2.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output0_thetastar_bin2"));
+  h_Zprime_SystVariations_DNN_output0_thetastar_bin3.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output0_thetastar_bin3"));
+  h_Zprime_SystVariations_DNN_output0_thetastar_bin4.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output0_thetastar_bin4"));
+  h_Zprime_SystVariations_DNN_output0_TopTag_thetastar_bin1.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output0_TopTag_thetastar_bin1"));
+  h_Zprime_SystVariations_DNN_output0_TopTag_thetastar_bin2.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output0_TopTag_thetastar_bin2"));
+  h_Zprime_SystVariations_DNN_output0_TopTag_thetastar_bin3.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output0_TopTag_thetastar_bin3"));
+  h_Zprime_SystVariations_DNN_output0_TopTag_thetastar_bin4.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output0_TopTag_thetastar_bin4"));
+  h_Zprime_SystVariations_DNN_output0_NoTopTag_thetastar_bin1.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output0_NoTopTag_thetastar_bin1"));
+  h_Zprime_SystVariations_DNN_output0_NoTopTag_thetastar_bin2.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output0_NoTopTag_thetastar_bin2"));
+  h_Zprime_SystVariations_DNN_output0_NoTopTag_thetastar_bin3.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output0_NoTopTag_thetastar_bin3"));
+  h_Zprime_SystVariations_DNN_output0_NoTopTag_thetastar_bin4.reset(new ZprimeSemiLeptonicSystematicsHists(ctx, "Zprime_SystVariations_DNN_output0_NoTopTag_thetastar_bin4"));
+
   // Book histograms
-  vector<string> histogram_tags = {"Weights_Init", "Weights_PU", "Weights_Lumi", "Weights_TopPt", "Weights_MCScale", "Weights_Prefiring", "Weights_TopTag_SF", "Corrections", "IdMuon_SF", "IdEle_SF", "IsoMuon_SF", "RecoEle_SF", "MuonReco_SF", "TriggerMuon_SF", "Btags1_SF", "NNInputsBeforeReweight", "TopTagVeto", "DNN_output0","DNN_output1","DNN_output2","DNN_output0_TopTag","DNN_output1_TopTag","DNN_output2_TopTag","DNN_output0_NoTopTag","DNN_output1_NoTopTag","DNN_output2_NoTopTag", "DNN_output0_thetastar_bin1", "DNN_output0_thetastar_bin2", "DNN_output0_thetastar_bin3", "DNN_output0_thetastar_bin4", "DNN_output0_TopTag_thetastar_bin1", "DNN_output0_TopTag_thetastar_bin2", "DNN_output0_TopTag_thetastar_bin3", "DNN_output0_TopTag_thetastar_bin4", "DNN_output0_NoTopTag_thetastar_bin1", "DNN_output0_NoTopTag_thetastar_bin2", "DNN_output0_NoTopTag_thetastar_bin3", "DNN_output0_NoTopTag_thetastar_bin4", "DNN_output0_TopTag_chi2_max", "DNN_output0_NoTopTag_chi2_max", "DNN_output0_thetastar_bin1_chi2_max", "DNN_output0_thetastar_bin2_chi2_max", "DNN_output0_thetastar_bin3_chi2_max", "DNN_output0_thetastar_bin4_chi2_max", "DNN_output0_TopTag_thetastar_bin1_chi2_max", "DNN_output0_TopTag_thetastar_bin2_chi2_max", "DNN_output0_TopTag_thetastar_bin3_chi2_max", "DNN_output0_TopTag_thetastar_bin4_chi2_max", "DNN_output0_NoTopTag_thetastar_bin1_chi2_max", "DNN_output0_NoTopTag_thetastar_bin2_chi2_max", "DNN_output0_NoTopTag_thetastar_bin3_chi2_max", "DNN_output0_NoTopTag_thetastar_bin4_chi2_max"};
+  vector<string> histogram_tags = {"Weights_Init", "Weights_PU", "Weights_Lumi", "Weights_TopPt", "Weights_MCScale", "Weights_Prefiring", "Weights_TopTag_SF", "Corrections", "IdMuon_SF", "IdEle_SF", "IsoMuon_SF", "RecoEle_SF", "MuonReco_SF", "TriggerMuon_SF", "Btags1_SF", "NNInputsBeforeReweight", "TopTagVeto", "DNN_output0","DNN_output1","DNN_output2","DNN_output0_TopTag","DNN_output1_TopTag","DNN_output2_TopTag","DNN_output0_NoTopTag","DNN_output1_NoTopTag","DNN_output2_NoTopTag", "DNN_output0_thetastar_bin1", "DNN_output0_thetastar_bin2", "DNN_output0_thetastar_bin3", "DNN_output0_thetastar_bin4", "DNN_output0_TopTag_thetastar_bin1", "DNN_output0_TopTag_thetastar_bin2", "DNN_output0_TopTag_thetastar_bin3", "DNN_output0_TopTag_thetastar_bin4", "DNN_output0_NoTopTag_thetastar_bin1", "DNN_output0_NoTopTag_thetastar_bin2", "DNN_output0_NoTopTag_thetastar_bin3", "DNN_output0_NoTopTag_thetastar_bin4"};
   book_histograms(ctx, histogram_tags);
 
   h_MulticlassNN_output.reset(new ZprimeSemiLeptonicMulticlassNNHists(ctx, "MulticlassNN"));
@@ -761,8 +810,8 @@ ZprimeAnalysisModule_applyNN::ZprimeAnalysisModule_applyNN(uhh2::Context& ctx){
   h_NNoutput1 = ctx.declare_event_output<double>("NNoutput1");
   h_NNoutput2 = ctx.declare_event_output<double>("NNoutput2");
   ////Only Ele or Mu variables!!
-  NNModule.reset( new NeuralNetworkModule(ctx, "/nfs/dust/cms/user/deleokse/RunII_106_v2/CMSSW_10_6_28/src/UHH2/ZprimeSemiLeptonic/KerasNN/NN_DeepAK8_UL18_muon/model.pb", "/nfs/dust/cms/user/deleokse/RunII_106_v2/CMSSW_10_6_28/src/UHH2/ZprimeSemiLeptonic/KerasNN/NN_DeepAK8_UL18_muon/model.config.pbtxt"));
-  //NNModule.reset( new NeuralNetworkModule(ctx, "/nfs/dust/cms/user/deleokse/RunII_106_v2/CMSSW_10_6_28/src/UHH2/ZprimeSemiLeptonic/KerasNN/NN_DeepAK8_UL18_ele/model.pb", "/nfs/dust/cms/user/deleokse/RunII_106_v2/CMSSW_10_6_28/src/UHH2/ZprimeSemiLeptonic/KerasNN/NN_DeepAK8_UL18_ele/model.config.pbtxt"));
+  //NNModule.reset( new NeuralNetworkModule(ctx, "/nfs/dust/cms/user/deleokse/RunII_106_v2/CMSSW_10_6_28/src/UHH2/ZprimeSemiLeptonic/KerasNN/NN_DeepAK8_UL18_muon/model.pb", "/nfs/dust/cms/user/deleokse/RunII_106_v2/CMSSW_10_6_28/src/UHH2/ZprimeSemiLeptonic/KerasNN/NN_DeepAK8_UL18_muon/model.config.pbtxt"));
+  NNModule.reset( new NeuralNetworkModule(ctx, "/nfs/dust/cms/user/deleokse/RunII_106_v2/CMSSW_10_6_28/src/UHH2/ZprimeSemiLeptonic/KerasNN/NN_DeepAK8_UL18_ele/model.pb", "/nfs/dust/cms/user/deleokse/RunII_106_v2/CMSSW_10_6_28/src/UHH2/ZprimeSemiLeptonic/KerasNN/NN_DeepAK8_UL18_ele/model.config.pbtxt"));
 
 }
 
@@ -995,91 +1044,86 @@ bool ZprimeAnalysisModule_applyNN::process(uhh2::Event& event){
   // out0=TTbar, out1=ST, out2=WJets
   if( out0 == max_score ){
     fill_histograms(event, "DNN_output0");
-    if( ZprimeTopTag_selection->passes(event) ) fill_histograms(event, "DNN_output0_TopTag");
-    else fill_histograms(event, "DNN_output0_NoTopTag");
+    h_Zprime_SystVariations_DNN_output0->fill(event);
+    if( ZprimeTopTag_selection->passes(event) ){
+      fill_histograms(event, "DNN_output0_TopTag");
+      h_Zprime_SystVariations_DNN_output0_TopTag->fill(event);
+    }else{
+      fill_histograms(event, "DNN_output0_NoTopTag");
+      h_Zprime_SystVariations_DNN_output0_NoTopTag->fill(event);
+    }
   }
 
   if( out1 == max_score ){
     fill_histograms(event, "DNN_output1");
-    if( ZprimeTopTag_selection->passes(event) ) fill_histograms(event, "DNN_output1_TopTag");
-    else fill_histograms(event, "DNN_output1_NoTopTag");
+    h_Zprime_SystVariations_DNN_output1->fill(event);
+    if( ZprimeTopTag_selection->passes(event) ){
+      fill_histograms(event, "DNN_output1_TopTag");
+      h_Zprime_SystVariations_DNN_output1_TopTag->fill(event);
+    }else{
+      fill_histograms(event, "DNN_output1_NoTopTag");
+      h_Zprime_SystVariations_DNN_output1_NoTopTag->fill(event);
+    }
   }
 
   if( out2 == max_score ){
     fill_histograms(event, "DNN_output2");
-    if( ZprimeTopTag_selection->passes(event) ) fill_histograms(event, "DNN_output2_TopTag");
-    else fill_histograms(event, "DNN_output2_NoTopTag");
+    h_Zprime_SystVariations_DNN_output2->fill(event);
+    if( ZprimeTopTag_selection->passes(event) ){
+      fill_histograms(event, "DNN_output2_TopTag");
+      h_Zprime_SystVariations_DNN_output2_TopTag->fill(event);
+    }else{
+      fill_histograms(event, "DNN_output2_NoTopTag");
+      h_Zprime_SystVariations_DNN_output2_NoTopTag->fill(event);
+    }
   }
 
   //Define categories on theta star to reduce ttbar background - only in SR == out0
   if( out0 == max_score ){
-    if(ThetaStar_selection_bin1->passes(event)){
-      fill_histograms(event, "DNN_output0_thetastar_bin1");
-    }else if(ThetaStar_selection_bin2->passes(event)){
-      fill_histograms(event, "DNN_output0_thetastar_bin2");
-    }else if(ThetaStar_selection_bin3->passes(event)){
-      fill_histograms(event, "DNN_output0_thetastar_bin3");
-    }else{
-      fill_histograms(event, "DNN_output0_thetastar_bin4");
-    }
-    if( ZprimeTopTag_selection->passes(event) ){
+    if(Chi2_selection->passes(event)){  // cut on chi2<30 - only in SR == out0
       if(ThetaStar_selection_bin1->passes(event)){
-        fill_histograms(event, "DNN_output0_TopTag_thetastar_bin1");
+        fill_histograms(event, "DNN_output0_thetastar_bin1");
+        h_Zprime_SystVariations_DNN_output0_thetastar_bin1->fill(event);
       }else if(ThetaStar_selection_bin2->passes(event)){
-        fill_histograms(event, "DNN_output0_TopTag_thetastar_bin2");
+        fill_histograms(event, "DNN_output0_thetastar_bin2");
+        h_Zprime_SystVariations_DNN_output0_thetastar_bin2->fill(event);
       }else if(ThetaStar_selection_bin3->passes(event)){
-        fill_histograms(event, "DNN_output0_TopTag_thetastar_bin3");
+        fill_histograms(event, "DNN_output0_thetastar_bin3");
+        h_Zprime_SystVariations_DNN_output0_thetastar_bin3->fill(event);
       }else{
-        fill_histograms(event, "DNN_output0_TopTag_thetastar_bin4");
-      }
-    }else{
-      if(ThetaStar_selection_bin1->passes(event)){
-        fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin1");
-      }else if(ThetaStar_selection_bin2->passes(event)){
-        fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin2");
-      }else if(ThetaStar_selection_bin3->passes(event)){
-        fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin3");
-      }else{
-        fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin4");
-      }
-    }
-
-    //Cut on chi2<30 - only in SR == out0
-    if(Chi2_selection->passes(event)){
-      if(ThetaStar_selection_bin1->passes(event)){
-        fill_histograms(event, "DNN_output0_thetastar_bin1_chi2_max");
-      }else if(ThetaStar_selection_bin2->passes(event)){
-        fill_histograms(event, "DNN_output0_thetastar_bin2_chi2_max");
-      }else if(ThetaStar_selection_bin3->passes(event)){
-        fill_histograms(event, "DNN_output0_thetastar_bin3_chi2_max");
-      }else{
-        fill_histograms(event, "DNN_output0_thetastar_bin4_chi2_max");
+        fill_histograms(event, "DNN_output0_thetastar_bin4");
+        h_Zprime_SystVariations_DNN_output0_thetastar_bin4->fill(event);
       }
       if( ZprimeTopTag_selection->passes(event) ){
-        fill_histograms(event, "DNN_output0_TopTag_chi2_max");
         if(ThetaStar_selection_bin1->passes(event)){
-          fill_histograms(event, "DNN_output0_TopTag_thetastar_bin1_chi2_max");
+          fill_histograms(event, "DNN_output0_TopTag_thetastar_bin1");
+          h_Zprime_SystVariations_DNN_output0_TopTag_thetastar_bin1->fill(event);
         }else if(ThetaStar_selection_bin2->passes(event)){
-          fill_histograms(event, "DNN_output0_TopTag_thetastar_bin2_chi2_max");
+          fill_histograms(event, "DNN_output0_TopTag_thetastar_bin2");
+          h_Zprime_SystVariations_DNN_output0_TopTag_thetastar_bin2->fill(event);
         }else if(ThetaStar_selection_bin3->passes(event)){
-          fill_histograms(event, "DNN_output0_TopTag_thetastar_bin3_chi2_max");
+          fill_histograms(event, "DNN_output0_TopTag_thetastar_bin3");
+          h_Zprime_SystVariations_DNN_output0_TopTag_thetastar_bin3->fill(event);
         }else{
-          fill_histograms(event, "DNN_output0_TopTag_thetastar_bin4_chi2_max");
+          fill_histograms(event, "DNN_output0_TopTag_thetastar_bin4");
+          h_Zprime_SystVariations_DNN_output0_TopTag_thetastar_bin4->fill(event);
         }
       }else{
-        fill_histograms(event, "DNN_output0_NoTopTag_chi2_max");
         if(ThetaStar_selection_bin1->passes(event)){
-          fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin1_chi2_max");
+          fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin1");
+          h_Zprime_SystVariations_DNN_output0_NoTopTag_thetastar_bin1->fill(event);
         }else if(ThetaStar_selection_bin2->passes(event)){
-          fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin2_chi2_max");
+          fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin2");
+          h_Zprime_SystVariations_DNN_output0_NoTopTag_thetastar_bin2->fill(event);
         }else if(ThetaStar_selection_bin3->passes(event)){
-          fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin3_chi2_max");
+          fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin3");
+          h_Zprime_SystVariations_DNN_output0_NoTopTag_thetastar_bin3->fill(event);
         }else{
-          fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin4_chi2_max");
+          fill_histograms(event, "DNN_output0_NoTopTag_thetastar_bin4");
+          h_Zprime_SystVariations_DNN_output0_NoTopTag_thetastar_bin4->fill(event);
         }
       }
-    }
-
+    } // end chi2 cut
   }//end out0
 
 

--- a/src/ZprimeSemiLeptonicHists.cxx
+++ b/src/ZprimeSemiLeptonicHists.cxx
@@ -503,6 +503,11 @@ void ZprimeSemiLeptonicHists::init(){
   leptop_thetastar     = book<TH1F>("leptop_thetastar", "leptop #theta^*", 70, -3.5, 3.5);
   cos_leptop_thetastar = book<TH1F>("cos_leptop_thetastar", "cos(leptop #theta^*)", 100, -1.0, 1.0);
 
+  // 2D sitributoin NJets/HT to extract custom btag SF
+  vector<float> bins_NJets = {2,3,4,5,6,7,20};
+  vector<float> bins_HT = {0,200,400,600,800,1000,1500,2000,3000,7000};
+  N_Jets_vs_HT  = book<TH2F>("N_Jets_vs_HT", "N_Jets_vs_HT", bins_NJets.size()-1, &bins_NJets[0], bins_HT.size()-1, &bins_HT[0]);
+
   // NN Hists
   NN_Mu_pt            = book<TH1F>("NN_Mu_pt", "NN_Mu_pt", 50, 0, 1000);
   NN_Mu_eta           = book<TH1F>("NN_Mu_eta", "NN_Mu_eta", 50, -2.5, 2.5);
@@ -1226,11 +1231,13 @@ void ZprimeSemiLeptonicHists::fill(const Event & event){
 
   double met = event.met->pt();
   double st = 0., st_jets = 0., st_lep = 0.;
+  double ht = 0.;
   double ht_lep = 0.;
   for(const auto & jet : *jets)           st_jets += jet.pt();
   for(const auto & electron : *electrons) st_lep += electron.pt();
   for(const auto & muon : *muons)         st_lep += muon.pt();
   st = st_jets + st_lep + met;
+  ht = st_jets +  met;
   ht_lep = st_lep + met;
 
   MET->Fill(met, weight);
@@ -1398,6 +1405,9 @@ void ZprimeSemiLeptonicHists::fill(const Event & event){
     leptop_thetastar->Fill(ang_leptop_thetastar, weight);
     cos_leptop_thetastar->Fill(TMath::Cos(ang_leptop_thetastar), weight);
   }
+
+
+  N_Jets_vs_HT->Fill(Njets, ht, weight);
 
   /*
   ███    ██ ███    ██

--- a/src/ZprimeSemiLeptonicSystematicsHists.cxx
+++ b/src/ZprimeSemiLeptonicSystematicsHists.cxx
@@ -1,0 +1,182 @@
+#include "UHH2/ZprimeSemiLeptonic/include/ZprimeSemiLeptonicSystematicsHists.h"
+#include "UHH2/ZprimeSemiLeptonic/include/ZprimeSemiLeptonicModules.h"
+#include "UHH2/core/include/Event.h"
+#include <UHH2/core/include/Utils.h>
+#include <UHH2/common/include/Utils.h>
+#include "UHH2/common/include/JetIds.h"
+#include <math.h>
+
+#include <UHH2/common/include/TTbarGen.h>
+#include <UHH2/common/include/TTbarReconstruction.h>
+#include <UHH2/common/include/ReconstructionHypothesisDiscriminators.h>
+
+#include <UHH2/core/include/LorentzVector.h>
+
+#include "TH1F.h"
+#include "TH2D.h"
+#include <iostream>
+#include <string>
+
+using namespace std;
+using namespace uhh2;
+
+ZprimeSemiLeptonicSystematicsHists::ZprimeSemiLeptonicSystematicsHists(uhh2::Context& ctx, const std::string& dirname):
+Hists(ctx, dirname) {
+
+  is_mc = ctx.get("dataset_type") == "MC";
+  is_Muon = ctx.get("channel") == "muon";
+
+  h_ele_reco        = ctx.get_handle< float >("weight_sfelec_reco");
+  h_ele_reco_up     = ctx.get_handle< float >("weight_sfelec_reco_up");
+  h_ele_reco_down   = ctx.get_handle< float >("weight_sfelec_reco_down");
+  h_ele_id          = ctx.get_handle< float >("weight_sfelec_id");
+  h_ele_id_up       = ctx.get_handle< float >("weight_sfelec_id_up");
+  h_ele_id_down     = ctx.get_handle< float >("weight_sfelec_id_down");
+  h_mu_reco         = ctx.get_handle< float >("muonrecSF_nominal");
+  h_mu_reco_up      = ctx.get_handle< float >("muonrecSF_up");
+  h_mu_reco_down    = ctx.get_handle< float >("muonrecSF_down");
+  h_mu_iso          = ctx.get_handle< float >("weight_sfmu_iso");
+  h_mu_iso_up       = ctx.get_handle< float >("weight_sfmu_iso_up");
+  h_mu_iso_down     = ctx.get_handle< float >("weight_sfmu_iso_down");
+  h_mu_id           = ctx.get_handle< float >("weight_sfmu_id");
+  h_mu_id_up        = ctx.get_handle< float >("weight_sfmu_id_up");
+  h_mu_id_down      = ctx.get_handle< float >("weight_sfmu_id_down");
+  h_mu_trigger      = ctx.get_handle< float >("weight_sfmu_trigger");
+  h_mu_trigger_up   = ctx.get_handle< float >("weight_sfmu_trigger_up");
+  h_mu_trigger_down = ctx.get_handle< float >("weight_sfmu_trigger_down");
+  h_pu              = ctx.get_handle< float >("weight_pu");
+  h_pu_up           = ctx.get_handle< float >("weight_pu_up");
+  h_pu_down         = ctx.get_handle< float >("weight_pu_down");
+  h_prefiring       = ctx.get_handle< float >("prefiringWeight");
+  h_prefiring_up    = ctx.get_handle< float >("prefiringWeightUp");
+  h_prefiring_down  = ctx.get_handle< float >("prefiringWeightDown");
+  h_toppt           = ctx.get_handle< float >("weight_toppt_nominal");
+  h_toppt_a_up      = ctx.get_handle< float >("weight_toppt_a_up");
+  h_toppt_a_down    = ctx.get_handle< float >("weight_toppt_a_down");
+  h_toppt_b_up      = ctx.get_handle< float >("weight_toppt_b_up");
+  h_toppt_b_down    = ctx.get_handle< float >("weight_toppt_b_down");
+  h_murmuf_upup     = ctx.get_handle< float >("weight_murmuf_upup");
+  h_murmuf_upnone   = ctx.get_handle< float >("weight_murmuf_upnone");
+  h_murmuf_noneup   = ctx.get_handle< float >("weight_murmuf_noneup");
+  h_murmuf_nonedown = ctx.get_handle< float >("weight_murmuf_nonedown");
+  h_murmuf_downnone = ctx.get_handle< float >("weight_murmuf_downnone");
+  h_murmuf_downdown = ctx.get_handle< float >("weight_murmuf_downdown");
+
+  h_BestZprimeCandidateChi2 = ctx.get_handle<ZprimeCandidate*>("ZprimeCandidateBestChi2");
+  h_is_zprime_reconstructed_chi2 = ctx.get_handle<bool>("is_zprime_reconstructed_chi2");
+  init();
+
+}
+
+void ZprimeSemiLeptonicSystematicsHists::init(){
+
+  // Zprime reconstruction
+  vector<float> bins_Zprime = {0,400,600,800,1000,1200,1400,1600,1800,2000,2200,2400,2600,2800,3000,3200,3400,3600,3800,4000,4400,4800,5200,5600,6000,6100};
+
+  M_Zprime                 = book<TH1F>("M_Zprime", "M_{t#bar{t}} [GeV]",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_mu_reco_up      = book<TH1F>("M_Zprime_mu_reco_up",   "M_{t#bar{t}} [GeV] mu_reco_up",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_mu_reco_down    = book<TH1F>("M_Zprime_mu_reco_down", "M_{t#bar{t}} [GeV] mu_reco_down",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_pu_up           = book<TH1F>("M_Zprime_pu_up",   "M_{t#bar{t}} [GeV] pu_up",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_pu_down         = book<TH1F>("M_Zprime_pu_down", "M_{t#bar{t}} [GeV] pu_down",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_prefiring_up    = book<TH1F>("M_Zprime_prefiring_up",   "M_{t#bar{t}} [GeV] prefiring_up",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_prefiring_down  = book<TH1F>("M_Zprime_prefiring_down", "M_{t#bar{t}} [GeV] prefiring_down",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_mu_id_up        = book<TH1F>("M_Zprime_mu_id_up",   "M_{t#bar{t}} [GeV] mu_id_up",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_mu_id_down      = book<TH1F>("M_Zprime_mu_id_down", "M_{t#bar{t}} [GeV] mu_id_down",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_mu_iso_up       = book<TH1F>("M_Zprime_mu_iso_up",   "M_{t#bar{t}} [GeV] mu_iso_up",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_mu_iso_down     = book<TH1F>("M_Zprime_mu_iso_down", "M_{t#bar{t}} [GeV] mu_iso_down",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_mu_trigger_up   = book<TH1F>("M_Zprime_mu_trigger_up",   "M_{t#bar{t}} [GeV] mu_trigger_up",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_mu_trigger_down = book<TH1F>("M_Zprime_mu_trigger_down", "M_{t#bar{t}} [GeV] mu_trigger_down",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_ele_id_up       = book<TH1F>("M_Zprime_ele_id_up",   "M_{t#bar{t}} [GeV] ele_id_up",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_ele_id_down     = book<TH1F>("M_Zprime_ele_id_down", "M_{t#bar{t}} [GeV] ele_id_down",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_ele_reco_up     = book<TH1F>("M_Zprime_ele_reco_up",   "M_{t#bar{t}} [GeV] ele_trigger_up",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_ele_reco_down   = book<TH1F>("M_Zprime_ele_reco_down", "M_{t#bar{t}} [GeV] ele_trigger_down",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_toppt_a_up      = book<TH1F>("M_Zprime_toppt_a_up",   "M_{t#bar{t}} [GeV] toppt_a_up",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_toppt_a_down    = book<TH1F>("M_Zprime_toppt_a_down", "M_{t#bar{t}} [GeV] toppt_a_down",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_toppt_b_up      = book<TH1F>("M_Zprime_toppt_b_up",   "M_{t#bar{t}} [GeV] toppt_b_up",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_toppt_b_down    = book<TH1F>("M_Zprime_toppt_b_down", "M_{t#bar{t}} [GeV] toppt_b_down",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_murmuf_upup     = book<TH1F>("M_Zprime_murmuf_upup", "M_{t#bar{t}} [GeV] murmuf_upup",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_murmuf_upnone   = book<TH1F>("M_Zprime_murmuf_upnone", "M_{t#bar{t}} [GeV] murmuf_upnone",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_murmuf_noneup   = book<TH1F>("M_Zprime_murmuf_noneup", "M_{t#bar{t}} [GeV] murmuf_noneup",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_murmuf_nonedown = book<TH1F>("M_Zprime_murmuf_nonedown", "M_{t#bar{t}} [GeV] murmuf_nonedown",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_murmuf_downnone = book<TH1F>("M_Zprime_murmuf_downnone", "M_{t#bar{t}} [GeV] murmuf_downnone",  bins_Zprime.size()-1, &bins_Zprime[0]);
+  M_Zprime_murmuf_downdown = book<TH1F>("M_Zprime_murmuf_downdown", "M_{t#bar{t}} [GeV] murmuf_downdown",  bins_Zprime.size()-1, &bins_Zprime[0]);
+}
+
+
+void ZprimeSemiLeptonicSystematicsHists::fill(const Event & event){
+
+  double weight = event.weight;
+  float ele_reco_nominal   = event.get(h_ele_reco);
+  float ele_reco_up        = event.get(h_ele_reco_up);
+  float ele_reco_down      = event.get(h_ele_reco_down);
+  float ele_id_nominal     = event.get(h_ele_id);
+  float ele_id_up          = event.get(h_ele_id_up);
+  float ele_id_down        = event.get(h_ele_id_down);
+  float mu_reco_nominal    = event.get(h_mu_reco);
+  float mu_reco_up         = event.get(h_mu_reco_up);
+  float mu_reco_down       = event.get(h_mu_reco_down);
+  float mu_iso_nominal     = event.get(h_mu_iso);
+  float mu_iso_up          = event.get(h_mu_iso_up);
+  float mu_iso_down        = event.get(h_mu_iso_down);
+  float mu_id_nominal      = event.get(h_mu_id);
+  float mu_id_up           = event.get(h_mu_id_up);
+  float mu_id_down         = event.get(h_mu_id_down);
+  float mu_trigger_nominal = event.get(h_mu_trigger);
+  float mu_trigger_up      = event.get(h_mu_trigger_up);
+  float mu_trigger_down    = event.get(h_mu_trigger_down);
+  float pu_nominal         = event.get(h_pu);
+  float pu_up              = event.get(h_pu_up);
+  float pu_down            = event.get(h_pu_down);
+  float prefiring_nominal  = event.get(h_prefiring);
+  float prefiring_up       = event.get(h_prefiring_up);
+  float prefiring_down     = event.get(h_prefiring_down);
+  float toppt_nominal      = event.get(h_toppt);
+  float toppt_a_up         = event.get(h_toppt_a_up);
+  float toppt_a_down       = event.get(h_toppt_a_down);
+  float toppt_b_up         = event.get(h_toppt_b_up);
+  float toppt_b_down       = event.get(h_toppt_b_down);
+  float murmuf_upup        = event.get(h_murmuf_upup);
+  float murmuf_upnone      = event.get(h_murmuf_upnone);
+  float murmuf_noneup      = event.get(h_murmuf_noneup);
+  float murmuf_nonedown    = event.get(h_murmuf_nonedown);
+  float murmuf_downnone    = event.get(h_murmuf_downnone);
+  float murmuf_downdown    = event.get(h_murmuf_downdown);
+
+  // only up/down variations
+  vector<string> names       = {"ele_reco", "ele_id", "mu_reco", "mu_iso", "mu_id", "mu_trigger", "pu", "prefiring", "toppt_a", "toppt_b"};
+  vector<float> syst_nominal = {ele_reco_nominal, ele_id_nominal, mu_reco_nominal, mu_iso_nominal, mu_id_nominal, mu_trigger_nominal, pu_nominal, prefiring_nominal, toppt_nominal, toppt_nominal};
+  vector<float> syst_up      = {ele_reco_up, ele_id_up, mu_reco_up, mu_iso_up, mu_id_up, mu_trigger_up, pu_up, prefiring_up, toppt_a_up, toppt_b_up};
+  vector<float> syst_down    = {ele_reco_down, ele_id_down, mu_reco_down, mu_iso_down, mu_id_down, mu_trigger_down, pu_down, prefiring_down, toppt_a_down, toppt_b_down};
+  vector<TH1F*> hists_up     = {M_Zprime_ele_reco_up, M_Zprime_ele_id_up, M_Zprime_mu_reco_up, M_Zprime_mu_iso_up, M_Zprime_mu_id_up, M_Zprime_mu_trigger_up, M_Zprime_pu_up, M_Zprime_prefiring_up, M_Zprime_toppt_a_up, M_Zprime_toppt_b_up};
+  vector<TH1F*> hists_down   = {M_Zprime_ele_reco_down, M_Zprime_ele_id_down, M_Zprime_mu_reco_down, M_Zprime_mu_iso_down, M_Zprime_mu_id_down, M_Zprime_mu_trigger_down, M_Zprime_pu_down, M_Zprime_prefiring_down, M_Zprime_toppt_a_down, M_Zprime_toppt_b_down};
+
+  // scale variations need special treatment
+  vector<float> syst_scale = {murmuf_upup, murmuf_upnone, murmuf_noneup, murmuf_nonedown, murmuf_downnone, murmuf_downdown};
+  vector<TH1F*> hists_scale = {M_Zprime_murmuf_upup, M_Zprime_murmuf_upnone, M_Zprime_murmuf_noneup, M_Zprime_murmuf_nonedown, M_Zprime_murmuf_downnone, M_Zprime_murmuf_downdown};
+
+  // Zprime reco
+  bool is_zprime_reconstructed_chi2 = event.get(h_is_zprime_reconstructed_chi2);
+  if(is_zprime_reconstructed_chi2 && is_mc){
+    ZprimeCandidate* BestZprimeCandidate = event.get(h_BestZprimeCandidateChi2);
+    float Mreco = BestZprimeCandidate->Zprime_v4().M();
+
+    M_Zprime->Fill(Mreco, weight);
+
+    // up/down variations
+    for(unsigned int i=0; i<names.size(); i++){
+        hists_up.at(i)->Fill(Mreco, weight * syst_up.at(i)/syst_nominal.at(i));
+        hists_down.at(i)->Fill(Mreco, weight * syst_down.at(i)/syst_nominal.at(i));
+    }
+    // scale variations
+    for(unsigned int i=0; i<6; i++){
+        hists_scale.at(i)->Fill(Mreco, weight * syst_scale.at(i));
+    }
+
+  }
+
+
+} //Method
+
+
+
+ZprimeSemiLeptonicSystematicsHists::~ZprimeSemiLeptonicSystematicsHists(){}


### PR DESCRIPTION
Fill Mtt histograms to be used in limit calculation with the up/down systematic variations.
So far most of the "simple" up/down variations are implemented.

Note that for the lepton scale factors, the default values of the sf handles have to be set to "1", and not to "-1" as it is implemented in UHH2.