### PR TITLE
[106X] bug fix: pdf weights

### DIFF
--- a/src/ZprimeAnalysisModule.cxx
+++ b/src/ZprimeAnalysisModule.cxx
@@ -448,8 +448,8 @@ ZprimeAnalysisModule::ZprimeAnalysisModule(uhh2::Context& ctx){
 
 bool ZprimeAnalysisModule::process(uhh2::Event& event){
 
-  if(debug)   cout << "++++++++++++ NEW EVENT ++++++++++++++" << endl;
-  if(debug)   cout<<" run.event: "<<event.run<<". "<<event.event<<endl;
+  if(debug) cout << "++++++++++++ NEW EVENT ++++++++++++++" << endl;
+  if(debug) cout << " run.event: " << event.run << ". " << event.event << endl;
   // Initialize reco flags with false
   event.set(h_is_zprime_reconstructed_chi2, false);
   event.set(h_is_zprime_reconstructed_correctmatch, false);
@@ -915,7 +915,7 @@ bool ZprimeAnalysisModule::process(uhh2::Event& event){
   fill_histograms(event, "CorrectMatchDiscriminator");
   if(debug) cout << "CorrectMatchDiscriminatorZprime: ok" << endl;
 
-  // select ttbar candidate with smallest chi2, fill Mtt hists 
+  // select ttbar candidate with smallest chi2, fill Mtt hists
   //Chi2DiscriminatorZprime->process(event);
   //fill_histograms(event, "Chi2Discriminator");
   //if(debug) cout << "Chi2DiscriminatorZprime: ok" << endl;

--- a/src/ZprimeSemiLeptonicPreselectionHists.cxx
+++ b/src/ZprimeSemiLeptonicPreselectionHists.cxx
@@ -262,9 +262,7 @@ void ZprimeSemiLeptonicPreselectionHists::init(){
     hist_names[i] = s_name;
 
     book<TH1F>(char_name, char_title,  1, 0.5, 1.5);
-
   }
-
 }
 
 
@@ -671,14 +669,13 @@ void ZprimeSemiLeptonicPreselectionHists::fill(const Event & event){
   S23->Fill(s23, weight);
   S33->Fill(s33, weight);
 
-
   sum_event_weights->Fill(1., weight);
 
   if(is_mc){
-    if(event.genInfo->systweights().size()){
+    int MY_FIRST_INDEX = 9;
+    if(is_dy || is_wjets || is_qcd_HTbinned || is_alps || is_azh || is_htott_scalar || is_htott_pseudo || is_zprimetott ) MY_FIRST_INDEX = 47;
+    if(event.genInfo->systweights().size() > (unsigned int) 100 + MY_FIRST_INDEX){
       float orig_weight = event.genInfo->originalXWGTUP();
-      int MY_FIRST_INDEX = 9;
-      if ( is_dy || is_wjets || is_qcd_HTbinned || is_alps || is_azh || is_htott_scalar || is_htott_pseudo || is_zprimetott ) MY_FIRST_INDEX = 47;
         for(int i=0; i<100; i++){
           double pdf_weight = event.genInfo->systweights().at(i+MY_FIRST_INDEX);
           const char* name = hist_names[i].c_str();
@@ -686,8 +683,6 @@ void ZprimeSemiLeptonicPreselectionHists::fill(const Event & event){
        }
     }
   }
-
-
 } //Method
 
 


### PR DESCRIPTION
This PR fixes the following exception, which appeared for some of the Z' 1% width samples:
```
( FATAL )  sframe_main        : app/sframe_main.cxx:70 (int main(int, char**)): STD exception caught
( FATAL )  sframe_main        : app/sframe_main.cxx:71 (int main(int, char**)): Message: vector::_M_range_check: __n (which is 146) >= this->size() (which is 146)
( FATAL )  sframe_main        : app/sframe_main.cxx:72 (int main(int, char**)): --> Stopping execution
```
Apparently for some events (~0.2-0.6%) the pdf weights are not properly stored leading to this problem.