### PR TITLE
add JEC/JER in AnalysisModule to obtain up/down variations

### DIFF
--- a/include/AK4JetCorrections.h
+++ b/include/AK4JetCorrections.h
@@ -1,0 +1,39 @@
+#pragma once
+#include "UHH2/core/include/AnalysisModule.h"
+#include "UHH2/core/include/Selection.h"
+#include "UHH2/core/include/Utils.h"
+
+#include "UHH2/common/include/ObjectIdUtils.h"
+#include "UHH2/common/include/NSelections.h"
+#include "UHH2/common/include/JetIds.h"
+#include "UHH2/common/include/JetCorrections.h"
+#include "UHH2/common/include/CleaningModules.h"
+#include "UHH2/common/include/YearRunSwitchers.h"
+
+class AK4JetCorrections: public uhh2::AnalysisModule {
+public:
+    AK4JetCorrections();
+
+    virtual bool process(uhh2::Event & event) override;
+    void init(uhh2::Context & ctx);
+
+private:
+    void fail_if_init() const;
+
+    std::unique_ptr<YearSwitcher> jet_corrector_MC;
+    std::shared_ptr<RunSwitcher> jec_switcher_UL16preVFP, jec_switcher_UL16postVFP, jec_switcher_UL17, jec_switcher_UL18;
+    std::unique_ptr<GenericJetResolutionSmearer> jet_resolution_smearer;
+
+    bool is_mc, is_data;
+    bool init_done = false;
+
+    Year year;
+
+    // Parameters for JEC & JLC sets
+    std::string jec_tag_UL16preVFP, jec_ver_UL16preVFP;
+    std::string jec_tag_UL16postVFP, jec_ver_UL16postVFP;
+    std::string jec_tag_UL17, jec_ver_UL17;
+    std::string jec_tag_UL18, jec_ver_UL18;
+    std::string jec_jet_coll;
+};
+

--- a/src/AK4JetCorrections.cc
+++ b/src/AK4JetCorrections.cc
@@ -1,0 +1,119 @@
+#include "../include/AK4JetCorrections.h"
+#include "UHH2/common/include/JetCorrections.h"
+#include "UHH2/common/include/JetCorrectionSets.h"
+#include "UHH2/common/include/MCWeight.h"
+#include "UHH2/common/include/EventVariables.h"
+#include "UHH2/common/include/CleaningModules.h"
+#include "UHH2/common/include/EventVariables.h"
+#include "UHH2/common/include/LumiSelection.h"
+#include "UHH2/common/include/Utils.h"
+#include "UHH2/common/include/TriggerSelection.h"
+
+using namespace uhh2;
+using namespace std;
+
+void AK4JetCorrections::fail_if_init() const{
+  if(init_done){
+    throw invalid_argument("AK4JetCorrections::init already called!");
+  }
+}
+
+
+AK4JetCorrections::AK4JetCorrections(){
+  jec_tag_UL16preVFP = "Summer19UL16APV";
+  jec_ver_UL16preVFP = "7";
+
+  jec_tag_UL16postVFP = "Summer19UL16";
+  jec_ver_UL16postVFP = "7";
+
+  jec_tag_UL17 = "Summer19UL17";
+  jec_ver_UL17 = "5";
+
+  jec_tag_UL18 = "Summer19UL18";
+  jec_ver_UL18 = "5";
+
+  jec_jet_coll = "AK4PFPuppi";
+}
+
+
+void AK4JetCorrections::init(Context & ctx){
+  if(init_done){
+    throw invalid_argument("AK4JetCorrections::init called twice!");
+  }
+  init_done = true;
+
+  is_data = ctx.get("dataset_type") == "DATA";
+  is_mc = ctx.get("dataset_type") == "MC";
+  year = extract_year(ctx);
+
+  if(is_mc){
+    jet_corrector_MC.reset(new YearSwitcher(ctx));
+    jet_corrector_MC->setupUL16preVFP(std::make_shared<GenericJetCorrector>(ctx, JERFiles::JECFilesMC(jec_tag_UL16preVFP, jec_ver_UL16preVFP, jec_jet_coll),"jets"));
+    jet_corrector_MC->setupUL16postVFP(std::make_shared<GenericJetCorrector>(ctx, JERFiles::JECFilesMC(jec_tag_UL16postVFP, jec_ver_UL16postVFP, jec_jet_coll),"jets"));
+    jet_corrector_MC->setupUL17(std::make_shared<GenericJetCorrector>(ctx, JERFiles::JECFilesMC(jec_tag_UL17, jec_ver_UL17, jec_jet_coll),"jets"));
+    jet_corrector_MC->setupUL18(std::make_shared<GenericJetCorrector>(ctx, JERFiles::JECFilesMC(jec_tag_UL18, jec_ver_UL18, jec_jet_coll),"jets"));
+
+   const Year & year = extract_year(ctx);
+    std::string jer_tag = "";
+    if (year == Year::isUL16preVFP) {
+      jer_tag = "Summer20UL16APV_JRV3";
+    } else if (year == Year::isUL16postVFP) {
+      jer_tag = "Summer20UL16_JRV3";
+    } else if (year == Year::isUL17) {
+      jer_tag = "Summer19UL17_JRV2";
+    } else if (year == Year::isUL18) {
+      jer_tag = "Summer19UL18_JRV2";
+    } else {
+      throw runtime_error("Cannot find suitable jet resolution file & scale factors for this year for JetResolutionSmearer");
+    }
+    jet_resolution_smearer.reset(new GenericJetResolutionSmearer(ctx, "jets", "genjets", JERFiles::JERPathStringMC(jer_tag,"AK4PFPuppi","SF"), JERFiles::JERPathStringMC(jer_tag,"AK4PFPuppi","PtResolution")));
+
+
+  }
+
+}
+
+  //propagate to MET
+  //apply type1 MET correction to RAW MET
+  //NB: jet with substracted muon Pt should be used
+  void correct_MET(const Event & event, double pt_thresh = 15., double eta_thresh_low=0., double eta_thresh_high=5.5){
+    //we start from raw MET
+    LorentzVector metv4= event.met->uncorr_v4();
+    for(auto & jet : *event.jets){
+      //thresholds on the corrected jets: pt > 15, EM fraction < 0.9
+      bool to_be_corrected = jet.v4().Pt() > 15.;
+      to_be_corrected = to_be_corrected && ( fabs(jet.v4().Eta())<eta_thresh_low || fabs(jet.v4().Eta())>eta_thresh_high || jet.v4().Pt() > pt_thresh );
+      to_be_corrected = to_be_corrected && (jet.neutralEmEnergyFraction()+jet.chargedEmEnergyFraction())<0.9;
+      if(to_be_corrected){
+        //slimmed MET is corrected by L1FastJet
+        auto factor_raw = jet.JEC_factor_raw();
+        auto L1factor_raw = jet.JEC_L1factor_raw();
+
+        LorentzVector L1corr =   (L1factor_raw*factor_raw)*jet.v4();            //L1 corrected jets
+        LorentzVector L123corr = jet.v4();                                      //L123 corrected jets (L23 in case of puppi)
+        metv4 -=  L123corr;
+
+        //slimmed MET is corrected by L1FastJet, for Puppi: L1factor_raw = 1 --> L1corr = raw-jet pT.
+        metv4 += L1corr;
+      }
+    }
+    event.met->set_pt(metv4.Pt());
+    event.met->set_phi(metv4.Phi());
+  }
+
+
+bool AK4JetCorrections::process(uhh2::Event & event){
+  if(!init_done){
+    throw runtime_error("AK4JetCorrections::init not called (has to be called in AnalysisModule constructor)");
+  }
+
+  if (is_mc) {
+    //cout << "Going to correct PUPPI Ak4 jets" << endl;
+    jet_corrector_MC->process(event);
+    jet_resolution_smearer->process(event);
+    correct_MET(event);
+  } 
+
+  return true;
+}
+

--- a/src/ZprimeAnalysisModule.cxx
+++ b/src/ZprimeAnalysisModule.cxx
@@ -39,6 +39,8 @@
 #include <UHH2/ZprimeSemiLeptonic/include/ZprimeSemiLeptonicCHSMatchHists.h>
 #include <UHH2/ZprimeSemiLeptonic/include/ZprimeCandidate.h>
 #include <UHH2/ZprimeSemiLeptonic/include/ElecTriggerSF.h>
+#include <UHH2/ZprimeSemiLeptonic/include/AK4JetCorrections.h>
+#include <UHH2/ZprimeSemiLeptonic/include/TopPuppiJetCorrections.h>
 
 #include <UHH2/common/include/TTbarGen.h>
 #include <UHH2/common/include/TTbarReconstruction.h>
@@ -71,6 +73,10 @@ public:
 protected:
 
   bool debug;
+
+  // Jet Corrections
+  std::unique_ptr<AK4JetCorrections> AK4jetCorr;
+  std::unique_ptr<TopPuppiJetCorrections> TopPuppijetCorr;
 
   // Cleaners
   std::unique_ptr<MuonCleaner> muon_cleaner_low, muon_cleaner_high;
@@ -304,6 +310,12 @@ ZprimeAnalysisModule::ZprimeAnalysisModule(uhh2::Context& ctx){
   // double a_toppt = 0.0615; // par a TopPt Reweighting
   // double b_toppt = -0.0005; // par b TopPt Reweighting
 
+  // Jet Corrections
+  AK4jetCorr.reset(new AK4JetCorrections());
+  AK4jetCorr->init(ctx);
+  TopPuppijetCorr.reset(new TopPuppiJetCorrections());
+  TopPuppijetCorr->init(ctx);
+
   // Modules
   LumiWeight_module.reset(new MCLumiWeight(ctx));
   PUWeight_module.reset(new MCPileupReweight(ctx, Sys_PU));
@@ -400,7 +412,7 @@ ZprimeAnalysisModule::ZprimeAnalysisModule(uhh2::Context& ctx){
   h_CHSMatchHists_afterBTag.reset(new ZprimeSemiLeptonicCHSMatchHists(ctx, "CHSMatch_afterBTag"));
 
   // Book histograms
-  vector<string> histogram_tags = {"Weights_Init", "Weights_HEM", "Weights_PU", "Weights_Lumi", "Weights_TopPt", "Weights_MCScale", "Weights_Prefiring", "Weights_TopTag_SF", "Weights_PS", "Muon1_LowPt", "Muon1_HighPt", "Muon1_Tot", "Ele1_LowPt", "Ele1_HighPt", "Ele1_Tot", "1Mu1Ele_LowPt", "1Mu1Ele_HighPt", "1Mu1Ele_Tot", "IdMuon_SF", "IdEle_SF", "IsoMuon_SF", "RecoEle_SF", "MuonReco_SF", "TriggerMuon", "TriggerEle", "TriggerMuon_SF", "TwoDCut_Muon", "TwoDCut_Ele", "Jet1", "Jet2", "MET", "HTlep", "BeforeBtagSF", "AfterBtagSF", "AfterCustomBtagSF", "Btags1", "NLOCorrections", "TriggerEle_SF", "TTbarCandidate", "CorrectMatchDiscriminator", "Chi2Discriminator", "NNInputsBeforeReweight"};
+  vector<string> histogram_tags = {"Weights_Init", "Uncorrected_jets", "Corrected_jets", "Weights_HEM", "Weights_PU", "Weights_Lumi", "Weights_TopPt", "Weights_MCScale", "Weights_Prefiring", "Weights_TopTag_SF", "Weights_PS", "Muon1_LowPt", "Muon1_HighPt", "Muon1_Tot", "Ele1_LowPt", "Ele1_HighPt", "Ele1_Tot", "1Mu1Ele_LowPt", "1Mu1Ele_HighPt", "1Mu1Ele_Tot", "IdMuon_SF", "IdEle_SF", "IsoMuon_SF", "RecoEle_SF", "MuonReco_SF", "TriggerMuon", "TriggerEle", "TriggerMuon_SF", "TwoDCut_Muon", "TwoDCut_Ele", "Jet1", "Jet2", "MET", "HTlep", "BeforeBtagSF", "AfterBtagSF", "AfterCustomBtagSF", "Btags1", "NLOCorrections", "TriggerEle_SF", "TTbarCandidate", "CorrectMatchDiscriminator", "Chi2Discriminator", "NNInputsBeforeReweight"};
   book_histograms(ctx, histogram_tags);
 
   lumihists_Weights_Init.reset(new LuminosityHists(ctx, "Lumi_Weights_Init"));
@@ -478,6 +490,27 @@ bool ZprimeAnalysisModule::process(uhh2::Event& event){
 
   fill_histograms(event, "Weights_Init");
   lumihists_Weights_Init->fill(event);
+
+  // remove JEC/JER from AK4 jets, AK8 jets and MET-> needed to re-apply JEC/JER with up/down variations
+  for (auto & jet:*event.jets){
+    jet.set_v4(jet.v4() * jet.JEC_factor_raw() );
+    jet.set_JEC_factor_raw(1);
+  }
+  for (auto & toppuppijet:*event.toppuppijets){
+    toppuppijet.set_v4(toppuppijet.v4() * toppuppijet.JEC_factor_raw() );
+    toppuppijet.set_JEC_factor_raw(1);
+  }
+
+  LorentzVector metv4= event.met->uncorr_v4();
+  event.met->set_pt(metv4.Pt());
+  event.met->set_phi(metv4.Phi());
+
+  fill_histograms(event, "Uncorrected_jets");
+
+  // Correct jets + MET
+  AK4jetCorr->process(event);
+  TopPuppijetCorr->process(event);
+  fill_histograms(event, "Corrected_jets");
 
   if(!HEM_selection->passes(event)){
     if(!isMC) return false;


### PR DESCRIPTION
With this PR it is possible to apply JEC/JER in the AnalysisModule, even if the corrections were already applied at Preselection level. 
First we remote the corrections from the AK4 jets, AK8 jets and from MET. Then we re-apply the JEC and JER. It is possible to apply the nominal corrections and the up/down variations by specifying the "jecsmear_direction" / "jersmear_direction" in the config file.

Note that an error occurs when trying to smear jets that have JER already applied: https://github.com/UHH2/UHH2/blob/RunII_106X_v2/common/src/JetCorrections.cxx#L613