### PR TITLE
[106X] add sum_event_weights histograms for mcscale and ps

### DIFF
--- a/include/ZprimeSemiLeptonicPreselectionHists.h
+++ b/include/ZprimeSemiLeptonicPreselectionHists.h
@@ -25,7 +25,7 @@ protected:
   bool is_azh;
   bool is_htott_scalar;
   bool is_htott_pseudo;
-  bool is_zprimetott;  
+  bool is_zprimetott;
 
 TH1F *N_jets, *pt_jet, *pt_jet1, *pt_jet2, *pt_jet3, *eta_jet, *eta_jet1, *eta_jet2, *eta_jet3, *phi_jet, *phi_jet1, *phi_jet2, *phi_jet3, *m_jet, *m_jet1, *m_jet2, *m_jet3, *csv_jet, *csv_jet1, *csv_jet2, *csv_jet3, *N_bJets_loose, *N_bJets_med, *N_bJets_tight;
 
@@ -39,7 +39,7 @@ TH1F *N_HOTVRjets, *pt_HOTVRjet, *pt_HOTVRjet1, *pt_HOTVRjet2, *pt_HOTVRjet3, *e
 
 TH1F *N_AK8Puppijets, *pt_AK8Puppijet, *pt_AK8Puppijet1, *pt_AK8Puppijet2, *pt_AK8Puppijet3, *eta_AK8Puppijet, *eta_AK8Puppijet1, *eta_AK8Puppijet2, *eta_AK8Puppijet3, *phi_AK8Puppijet, *phi_AK8Puppijet1, *phi_AK8Puppijet2, *phi_AK8Puppijet3, *mSD_AK8Puppijet, *mSD_AK8Puppijet1, *mSD_AK8Puppijet2, *mSD_AK8Puppijet3, *N_subjets_AK8Puppijet, *N_subjets_AK8Puppijet1, *N_subjets_AK8Puppijet2, *N_subjets_AK8Puppijet3, *N_daughters_AK8Puppijet, *N_daughters_AK8Puppijet1, *N_daughters_AK8Puppijet2, *N_daughters_AK8Puppijet3, *dRmin_AK8_AK8Puppijet, *dRmin_AK8_AK8Puppijet1, *dRmin_AK8_AK8Puppijet2, *dRmin_AK8_AK8Puppijet3, *dRmin_mu_AK8Puppijet, *dRmin_mu_AK8Puppijet1, *dRmin_mu_AK8Puppijet2, *dRmin_mu_AK8Puppijet3, *tau1_AK8Puppijet, *tau1_AK8Puppijet1, *tau1_AK8Puppijet2, *tau1_AK8Puppijet3, *tau2_AK8Puppijet, *tau2_AK8Puppijet1, *tau2_AK8Puppijet2, *tau2_AK8Puppijet3, *tau3_AK8Puppijet, *tau3_AK8Puppijet1, *tau3_AK8Puppijet2, *tau3_AK8Puppijet3, *tau21_AK8Puppijet, *tau21_AK8Puppijet1, *tau21_AK8Puppijet2, *tau21_AK8Puppijet3, *tau32_AK8Puppijet, *tau32_AK8Puppijet1, *tau32_AK8Puppijet2, *tau32_AK8Puppijet3;
 
-TH1F *NPV, *MET, *MET_rebin, *MET_rebin2, *MET_rebin3, *ST, *ST_rebin, *ST_rebin2, *ST_rebin3, *STjets, *STjets_rebin, *STjets_rebin2, *STjets_rebin3, *STlep, *STlep_rebin, *STlep_rebin2, *STlep_rebin3, *S11, *S12, *S13, *S22, *S23, *S33, *sum_event_weights;
+TH1F *NPV, *MET, *MET_rebin, *MET_rebin2, *MET_rebin3, *ST, *ST_rebin, *ST_rebin2, *ST_rebin3, *STjets, *STjets_rebin, *STjets_rebin2, *STjets_rebin3, *STlep, *STlep_rebin, *STlep_rebin2, *STlep_rebin3, *S11, *S12, *S13, *S22, *S23, *S33, *sum_event_weights,  *sum_event_weights_mcscale_upup, *sum_event_weights_mcscale_upnone, *sum_event_weights_mcscale_noneup, *sum_event_weights_mcscale_nonedown, *sum_event_weights_mcscale_downnone, *sum_event_weights_mcscale_downdown, *sum_event_weights_isr_up, *sum_event_weights_isr_down, *sum_event_weights_fsr_up, *sum_event_weights_fsr_down;
 
 TH2F *dRmin_ptrel_mu, *dRmin_ptrel_mu1, *dRmin_ptrel_ele, *dRmin_ptrel_ele1;
 

--- a/src/ZprimeSemiLeptonicPreselectionHists.cxx
+++ b/src/ZprimeSemiLeptonicPreselectionHists.cxx
@@ -245,22 +245,28 @@ void ZprimeSemiLeptonicPreselectionHists::init(){
   S33 = book<TH1F>("S33", "S_{33}", 50, 0, 1);
 
   sum_event_weights = book<TH1F>("sum_event_weights", "counting experiment", 1, 0.5, 1.5);
+  sum_event_weights_mcscale_upup = book<TH1F>("sum_event_weights_mcscale_upup", "counting experiment", 1, 0.5, 1.5);
+  sum_event_weights_mcscale_upnone = book<TH1F>("sum_event_weights_mcscale_upnone", "counting experiment", 1, 0.5, 1.5);
+  sum_event_weights_mcscale_noneup = book<TH1F>("sum_event_weights_mcscale_noneup", "counting experiment", 1, 0.5, 1.5);
+  sum_event_weights_mcscale_nonedown = book<TH1F>("sum_event_weights_mcscale_nonedown", "counting experiment", 1, 0.5, 1.5);
+  sum_event_weights_mcscale_downnone = book<TH1F>("sum_event_weights_mcscale_downnone", "counting experiment", 1, 0.5, 1.5);
+  sum_event_weights_mcscale_downdown = book<TH1F>("sum_event_weights_mcscale_downdown", "counting experiment", 1, 0.5, 1.5);
+  sum_event_weights_isr_up = book<TH1F>("sum_event_weights_isr_up", "counting experiment", 1, 0.5, 1.5);
+  sum_event_weights_isr_down = book<TH1F>("sum_event_weights_isr_down", "counting experiment", 1, 0.5, 1.5);
+  sum_event_weights_fsr_up = book<TH1F>("sum_event_weights_fsr_up", "counting experiment", 1, 0.5, 1.5);
+  sum_event_weights_fsr_down = book<TH1F>("sum_event_weights_fsr_down", "counting experiment", 1, 0.5, 1.5);
 
   // calculate sum of event weights with PDF replicas
   for(int i=0; i<100; i++){
     std::stringstream ss_name;
     ss_name << "sum_event_weights_PDF_" << i+1;
-
     stringstream ss_title;
     ss_title << "counting experiment for PDF No. "  << i+1 << " out of 100" ;
-
     std::string s_name = ss_name.str();
     std::string s_title = ss_title.str();
     const char* char_name = s_name.c_str();
     const char* char_title = s_title.c_str();
-
     hist_names[i] = s_name;
-
     book<TH1F>(char_name, char_title,  1, 0.5, 1.5);
   }
 }
@@ -670,17 +676,39 @@ void ZprimeSemiLeptonicPreselectionHists::fill(const Event & event){
   S33->Fill(s33, weight);
 
   sum_event_weights->Fill(1., weight);
-
   if(is_mc){
+    // mcscale
+    if(is_dy || is_wjets || is_qcd_HTbinned || is_alps || is_azh || is_htott_scalar || is_htott_pseudo || is_zprimetott){
+      sum_event_weights_mcscale_upup->Fill(1., weight * event.genInfo->systweights().at(20) / event.genInfo->originalXWGTUP());
+      sum_event_weights_mcscale_upnone->Fill(1., weight * event.genInfo->systweights().at(5) / event.genInfo->originalXWGTUP());
+      sum_event_weights_mcscale_noneup->Fill(1., weight * event.genInfo->systweights().at(15) / event.genInfo->originalXWGTUP());
+      sum_event_weights_mcscale_nonedown->Fill(1., weight * event.genInfo->systweights().at(30) / event.genInfo->originalXWGTUP());
+      sum_event_weights_mcscale_downnone->Fill(1., weight * event.genInfo->systweights().at(10) / event.genInfo->originalXWGTUP());
+      sum_event_weights_mcscale_downdown->Fill(1., weight * event.genInfo->systweights().at(40) / event.genInfo->originalXWGTUP());
+    }
+    else{
+      sum_event_weights_mcscale_upup->Fill(1., weight * event.genInfo->systweights().at(4) / event.genInfo->originalXWGTUP());
+      sum_event_weights_mcscale_upnone->Fill(1., weight * event.genInfo->systweights().at(1) / event.genInfo->originalXWGTUP());
+      sum_event_weights_mcscale_noneup->Fill(1., weight * event.genInfo->systweights().at(3) / event.genInfo->originalXWGTUP());
+      sum_event_weights_mcscale_nonedown->Fill(1., weight * event.genInfo->systweights().at(6) / event.genInfo->originalXWGTUP());
+      sum_event_weights_mcscale_downnone->Fill(1., weight * event.genInfo->systweights().at(2) / event.genInfo->originalXWGTUP());
+      sum_event_weights_mcscale_downdown->Fill(1., weight * event.genInfo->systweights().at(8) / event.genInfo->originalXWGTUP());
+    }
+    // isr, fsr
+    sum_event_weights_isr_up->Fill(1., weight * event.genInfo->weights().at(27) / event.genInfo->weights().at(0));
+    sum_event_weights_isr_down->Fill(1., weight * event.genInfo->weights().at(26) / event.genInfo->weights().at(0));
+    sum_event_weights_fsr_up->Fill(1., weight * event.genInfo->weights().at(5) / event.genInfo->weights().at(0));
+    sum_event_weights_fsr_down->Fill(1., weight * event.genInfo->weights().at(4) / event.genInfo->weights().at(0));
+    // pdf
     int MY_FIRST_INDEX = 9;
-    if(is_dy || is_wjets || is_qcd_HTbinned || is_alps || is_azh || is_htott_scalar || is_htott_pseudo || is_zprimetott ) MY_FIRST_INDEX = 47;
+    if(is_dy || is_wjets || is_qcd_HTbinned || is_alps || is_azh || is_htott_scalar || is_htott_pseudo || is_zprimetott) MY_FIRST_INDEX = 47;
     if(event.genInfo->systweights().size() > (unsigned int) 100 + MY_FIRST_INDEX){
       float orig_weight = event.genInfo->originalXWGTUP();
-        for(int i=0; i<100; i++){
-          double pdf_weight = event.genInfo->systweights().at(i+MY_FIRST_INDEX);
-          const char* name = hist_names[i].c_str();
-          hist(name)->Fill(1.,weight * pdf_weight / orig_weight);
-       }
+      for(int i=0; i<100; i++){
+        double pdf_weight = event.genInfo->systweights().at(i+MY_FIRST_INDEX);
+        const char* name = hist_names[i].c_str();
+        hist(name)->Fill(1.,weight * pdf_weight / orig_weight);
+      }
     }
   }
 } //Method


### PR DESCRIPTION
This PR adds histograms for the counting experiment (`sum_event_weights `) for mc and ps scales.
We need this in order to factor out the respective normalization uncertainties.