### PR TITLE
[106X] remove boolean for blinding data -> needed for stat. tests in CR

### DIFF
--- a/src/ZprimeSemiLeptonicHists.cxx
+++ b/src/ZprimeSemiLeptonicHists.cxx
@@ -1311,8 +1311,7 @@ void ZprimeSemiLeptonicHists::fill(const Event & event){
   // Zprime reco
   bool is_zprime_reconstructed_chi2 = event.get(h_is_zprime_reconstructed_chi2);
   bool is_zprime_reconstructed_correctmatch = event.get(h_is_zprime_reconstructed_correctmatch);
-  // added "is_mc" to blind data in mttbar hists
-  if(is_zprime_reconstructed_chi2 && is_mc){
+  if(is_zprime_reconstructed_chi2){
     ZprimeCandidate* BestZprimeCandidate = event.get(h_BestZprimeCandidateChi2);
     float Mreco = BestZprimeCandidate->Zprime_v4().M();
     float chi2 = BestZprimeCandidate->discriminator("chi2_total");


### PR DESCRIPTION
m(tt) histograms are now not longer blinded for data, since it's needed for the statistical test.
Let's be careful and ensure to only look at the CRs!